### PR TITLE
Remove saved searches and search history if an exhibit is not searchable

### DIFF
--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -59,6 +59,11 @@ module Spotlight
         config.show.merge! show unless show.blank?
         config.index.merge! index unless index.blank?
 
+        unless exhibit.searchable?
+          config.navbar.partials[:saved_searches].if = false
+          config.navbar.partials[:search_history].if = false
+        end
+
         config.default_autocomplete_solr_params[:fl] ||= "#{config.solr_document_model.unique_key} #{config.view_config(:show).title_field} #{config.view_config(:show).thumbnail_field}"
 
         config.default_solr_params = config.default_solr_params.merge(default_solr_params)

--- a/spec/features/update_appearance_spec.rb
+++ b/spec/features/update_appearance_spec.rb
@@ -52,4 +52,22 @@ describe "Update the appearance", :type => :feature do
     # Type is now sorted last
     expect(page).to have_css("#nested-sort-fields .dd-item:nth-child(5) h3", text: "Type")
   end
+
+  it "should hide search features when the exhibit is not searchable" do
+    visit spotlight.exhibit_dashboard_path(exhibit)
+    within "#sidebar" do
+      click_link "Appearance"
+    end
+
+    uncheck "Searchable (offer searchbox and facet sidebar)"
+
+    click_button "Save changes"
+
+    visit spotlight.exhibit_root_path(exhibit)
+
+    expect(page).to_not have_link "Saved Searches"
+    expect(page).to_not have_link "History"
+    expect(page).to_not have_content "Limit your search"
+    expect(page).to_not have_css ".search-query-form"
+  end
 end


### PR DESCRIPTION
Fixes #827 