### PR TITLE
Show uploaded non-repository images in OSD viewer on record view...

### DIFF
--- a/app/models/concerns/spotlight/solr_document.rb
+++ b/app/models/concerns/spotlight/solr_document.rb
@@ -15,6 +15,12 @@ module Spotlight
       
       before_save :save_owned_tags
       after_save :reindex
+
+      ::SolrDocument.use_extension(Spotlight::SolrDocument::UploadedResource) do |document|
+        document[Spotlight::Engine.config.full_image_field].present? &&
+        document[:spotlight_resource_type_ssm].present? &&
+        document[:spotlight_resource_type_ssm].include?("spotlight/resources/uploads")
+      end
     end
     
     module ClassMethods  

--- a/app/models/concerns/spotlight/solr_document/uploaded_resource.rb
+++ b/app/models/concerns/spotlight/solr_document/uploaded_resource.rb
@@ -1,0 +1,25 @@
+module Spotlight::SolrDocument::UploadedResource
+  def to_openseadragon(*args)
+    self[Spotlight::Engine.config.full_image_field].each_with_index.map do |image_url, index|
+      {LegacyImagePyramidTileSource.new(
+         image_url,
+         {width: self[:spotlight_full_image_width_ssm][index],
+          height: self[:spotlight_full_image_height_ssm][index]}
+       ) => {}
+      } 
+    end
+  end
+  class LegacyImagePyramidTileSource
+    attr_reader :to_tilesource
+    def initialize(url, dimensions={})
+      @to_tilesource = {
+        type: 'legacy-image-pyramid',
+        levels:[{
+          url: url,
+          width: dimensions[:width],
+          height: dimensions[:height]
+        }]
+      }
+    end
+  end
+end

--- a/app/models/spotlight/resources/upload.rb
+++ b/app/models/spotlight/resources/upload.rb
@@ -21,8 +21,12 @@ module Spotlight
     def to_solr_hash
       solr_hash = {
         ::SolrDocument.unique_key.to_sym => compound_id,
-        exhibit.blacklight_config.index.full_image_field => url.url
+        exhibit.blacklight_config.index.full_image_field => url.url,
+        spotlight_resource_type_ssm: self.class.to_s.tableize
       }
+
+      add_image_dimensions(solr_hash)
+
       Spotlight::ItemUploader.configured_versions.each do |config|
         solr_hash[exhibit.blacklight_config.index.send(config[:blacklight_config_field])] = url.send(config[:version]).url
       end
@@ -30,6 +34,12 @@ module Spotlight
         solr_hash[config[:solr_field]] = data[key]
       end
       solr_hash
+    end
+
+    def add_image_dimensions(solr_hash)
+      dimensions = ::MiniMagick::Image.open(url.file.file)[:dimensions]
+      solr_hash[:spotlight_full_image_width_ssm] = dimensions.first
+      solr_hash[:spotlight_full_image_height_ssm] = dimensions.last
     end
 
     def compound_id

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 4.0", ">= 4.0.1"
   s.add_dependency "blacklight", "~> 5.8.0"
-  s.add_dependency "autoprefixer-rails"
+  s.add_dependency "autoprefixer-rails", "< 5.0.0"
   s.add_dependency "cancancan"
   s.add_dependency "sir-trevor-rails"
   s.add_dependency "carrierwave"

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -43,6 +43,9 @@ module Spotlight
     Spotlight::Engine.config.solr_fields.string_suffix = "_ssim".freeze
     Spotlight::Engine.config.solr_fields.text_suffix = "_tesim".freeze
 
+    # The solr field that original (largest) images will be stored.
+    Spotlight::Engine.config.full_image_field = :full_image_url_ssm
+
     Blacklight::Engine.config.inject_blacklight_helpers = false
     
     # Query parameters for autocomplete requests

--- a/spec/models/spotlight/resources/upload_spec.rb
+++ b/spec/models/spotlight/resources/upload_spec.rb
@@ -10,6 +10,7 @@ describe Spotlight::Resources::Upload, :type => :model do
       subject.id = "1"
       subject.data = {title: "Title Data"}
       allow(subject).to receive(:url).and_return(stub_model(Spotlight::ItemUploader))
+      allow(subject.url.file).to receive(:file).and_return(File.expand_path(File.join('..', 'fixtures', '800x600.png'), Rails.root))
       allow(subject.exhibit).to receive(:blacklight_config).and_return(
         Blacklight::Configuration.new do |config|
           config.index.title_field = :configured_title_field
@@ -25,10 +26,17 @@ describe Spotlight::Resources::Upload, :type => :model do
     it 'should have a title field using the exhibit specific blacklight_config' do
       expect(subject.to_solr[:configured_title_field]).to eq 'Title Data'
     end
+    it 'should have a spotlight_resource_type field' do
+      expect(subject.to_solr[:spotlight_resource_type_ssm]).to eq 'spotlight/resources/uploads'
+    end
     it 'should have the various image fields' do
       expect(subject.to_solr).to have_key :configured_full_image_field
       expect(subject.to_solr).to have_key :configured_thumbnail_field
       expect(subject.to_solr).to have_key :configured_square_field
+    end
+    it 'should have the full image dimensions fields' do
+      expect(subject.to_solr[:spotlight_full_image_height_ssm]).to eq 600
+      expect(subject.to_solr[:spotlight_full_image_width_ssm]).to eq 800
     end
   end
 end

--- a/spec/models/spotlight/solr_document_uploaded_resource_spec.rb
+++ b/spec/models/spotlight/solr_document_uploaded_resource_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Spotlight::SolrDocument::UploadedResource, :type => :model do
+  let(:valid_resource) { ::SolrDocument.new(id: '123', full_image_url_ssm: ["http://example.com/png.png"], spotlight_full_image_height_ssm: ["1400"], spotlight_full_image_width_ssm: ["1000"], spotlight_resource_type_ssm: ["spotlight/resources/uploads"]) }
+  describe 'SolrDocument.use_extension' do
+    it 'should not include the uploaded resource extension when there is no full image field' do
+      expect(::SolrDocument.new(id: '123', spotlight_resource_type_ssm: ["spotlight/resources/uploads"])).to_not be_a_kind_of(Spotlight::SolrDocument::UploadedResource)
+    end
+    it 'should not include the uploaded resource extension when the spotlight resource type is not correct' do
+      expect(::SolrDocument.new(id: '123', full_image_url_ssm: ["http://example.com/png.png"], spotlight_resource_type_ssm: ["not-correct"])).to_not be_a_kind_of(Spotlight::SolrDocument::UploadedResource)
+    end
+    it 'should include the uploaded resource extension when the correct fields are present with the correct data' do
+      expect(valid_resource).to be_a_kind_of(Spotlight::SolrDocument::UploadedResource)
+    end
+  end
+  describe 'to_openseadragon' do
+    let(:subject) { valid_resource.to_openseadragon }
+    it 'should include hashes for each full_image_url_ssm' do
+      expect(subject).to be_an Array
+      expect(subject.length).to eq 1
+      expect(subject.first.keys.length).to eq 1
+    end
+    it 'the hashes key should be a LegacyImagePyramidTileSource object' do
+      expect(subject.first.keys.first).to be_a(Spotlight::SolrDocument::UploadedResource::LegacyImagePyramidTileSource)
+    end
+    describe 'LegacyImagePyramidTileSource' do
+      let(:subject) { valid_resource.to_openseadragon.first.keys.first.to_tilesource }
+      it 'should be a hash' do
+        expect(subject).to be_a Hash
+      end
+      it 'should be a legacy image pyramid type' do
+        expect(subject[:type]).to eq 'legacy-image-pyramid'
+      end
+      describe 'levels' do
+        it 'should include one level' do
+          expect(subject[:levels].length).to eq 1
+        end
+        it 'should include the image url' do
+          expect(subject[:levels].first[:url]).to eq "http://example.com/png.png"
+        end
+        it 'should include the height and width from the document' do
+          expect(subject[:levels].first[:height]).to eq "1400"
+          expect(subject[:levels].first[:width]).to eq "1000"
+        end
+      end
+    end
+  end
+end

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -28,7 +28,7 @@ class CatalogController < ApplicationController
     # solr field configuration for search results/index views
     config.index.title_field = 'full_title_tesim'
     config.index.display_type_field = 'content_metadata_type_ssm'
-    config.index.full_image_field = :full_image_url_ssm
+    config.index.full_image_field = Spotlight::Engine.config.full_image_field
     config.index.thumbnail_field = :thumbnail_url_ssm
     config.index.square_image_field = :thumbnail_square_url_ssm
 


### PR DESCRIPTION
...using legacy image pyramid.

Closes #838 

![osd-viewer](https://cloud.githubusercontent.com/assets/96776/5747042/afe05be4-9be9-11e4-8c5f-f71d6b072561.gif)
