### PR TITLE
Allow exhibit specific fields to be populated when uploading a non-repo item

### DIFF
--- a/app/assets/javascripts/spotlight/catalog_edit.js
+++ b/app/assets/javascripts/spotlight/catalog_edit.js
@@ -12,7 +12,7 @@ Spotlight.onLoad(function() {
         url: $('#solr_document_exhibit_tag_list').data('autocomplete_url'),
         ttl: 1,
         filter: function(list) {
-          return $.map(list.tags, function(tag) { return { name: tag }; });
+          return $.map(list, function(tag) { return { name: tag }; });
         }
       }
     });

--- a/app/controllers/spotlight/resources/upload_controller.rb
+++ b/app/controllers/spotlight/resources/upload_controller.rb
@@ -31,7 +31,11 @@ module Spotlight::Resources
     end
 
     def resource_params
-      params.require(:resources_upload).permit(:url, data: Spotlight::Resources::Upload.fields(current_exhibit).keys)
+      params.require(:resources_upload).permit(:url, data: data_param_keys)
+    end
+
+    def data_param_keys
+      Spotlight::Resources::Upload.fields(current_exhibit).keys + current_exhibit.custom_fields.map(&:field)
     end
 
   end

--- a/app/models/spotlight/custom_field.rb
+++ b/app/models/spotlight/custom_field.rb
@@ -33,7 +33,7 @@ module Spotlight
     end
 
     def configured_to_display?
-      if index_fields_config["enabled"]
+      if index_fields_config && index_fields_config["enabled"]
         view_types.any? do |view|
           index_fields_config[view.to_s]
         end
@@ -50,7 +50,7 @@ module Spotlight
     end
 
     def index_fields_config
-      exhibit.blacklight_configuration[:index_fields][field]
+      exhibit.blacklight_configuration.blacklight_config[:index_fields][field]
     end
 
     def should_generate_new_friendly_id?

--- a/app/models/spotlight/resources/upload.rb
+++ b/app/models/spotlight/resources/upload.rb
@@ -31,9 +31,12 @@ module Spotlight
 
       add_image_dimensions(solr_hash)
 
+      add_custom_fields(solr_hash)
+
       Spotlight::ItemUploader.configured_versions.each do |config|
         solr_hash[exhibit.blacklight_config.index.send(config[:blacklight_config_field])] = url.send(config[:version]).url
       end
+
       configured_fields.each do |key, config|
         if data[key].present?
           solr_hash[config.solr_field] = data[key]
@@ -46,6 +49,14 @@ module Spotlight
       dimensions = ::MiniMagick::Image.open(url.file.file)[:dimensions]
       solr_hash[:spotlight_full_image_width_ssm] = dimensions.first
       solr_hash[:spotlight_full_image_height_ssm] = dimensions.last
+    end
+
+    def add_custom_fields(solr_hash)
+      exhibit.custom_fields.each do |custom_field|
+        if data[custom_field.field].present?
+          solr_hash[custom_field.field] = data[custom_field.field]
+        end
+      end
     end
 
     def compound_id

--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -5,7 +5,7 @@
       <% current_exhibit.custom_fields.each do |field| %>
         <div class="form-group">
           <%= d.label field.field, field.label %>
-          <%= d.text_field_without_bootstrap field.field, value: document.sidecar(current_exhibit).data[field.field], class: 'form-control' %>
+          <%= d.text_field_without_bootstrap field.field, value: document[field.field], class: 'form-control' %>
           <% unless field.configured_to_display? %>
             <p class="bg-warning help-block">
               <%= t(:'.blank_field_warning_html',

--- a/app/views/spotlight/resources/upload/_single_item_form.html.erb
+++ b/app/views/spotlight/resources/upload/_single_item_form.html.erb
@@ -4,6 +4,9 @@
     <% Spotlight::Resources::Upload.fields(current_exhibit).each do |field, config| %>
       <%= d.send((config.form_field_type || :text_field), field) %>
     <% end %>
+    <% current_exhibit.custom_fields.each do |custom_field| %>
+      <%= d.text_field custom_field.field, label: custom_field.label %>
+    <% end %>
   <% end %>
   <div class="form-actions">
     <div class="primary-actions">

--- a/spec/features/upload_non_repository_item_spec.rb
+++ b/spec/features/upload_non_repository_item_spec.rb
@@ -1,8 +1,9 @@
 require "spec_helper"
 
 describe "Uploading a non-repository item", :type => :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
-  let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
+  let!(:exhibit) { FactoryGirl.create(:exhibit) }
+  let!(:custom_field) { FactoryGirl.create(:custom_field, exhibit: exhibit) }
+  let!(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as exhibit_curator }
 
   describe "upload" do
@@ -17,6 +18,7 @@ describe "Uploading a non-repository item", :type => :feature do
         expect(page).to have_css('textarea#resources_upload_data_description')
         expect(page).to have_css('#resources_upload_data_attribution[type="text"]')
         expect(page).to have_css('#resources_upload_data_date[type="text"]')
+        expect(page).to have_css("#resources_upload_data_#{custom_field.field}[type='text']")
       end
     end
   end

--- a/spec/models/spotlight/custom_field_spec.rb
+++ b/spec/models/spotlight/custom_field_spec.rb
@@ -75,21 +75,21 @@ describe Spotlight::CustomField, :type => :model do
       subject.field = 'foo_tesim'
     end
     it 'should be truthy when a view has been configured true' do
-      exhibit.blacklight_configuration.index_fields['foo_tesim'] =
+      exhibit.blacklight_configuration.blacklight_config.index_fields['foo_tesim'] =
         Blacklight::Configuration::IndexField.new(label: "Label", enabled: true, view_name: true)
       subject.save
 
       expect(subject).to be_configured_to_display
     end
     it 'should be truthey for show views when enabled' do
-      exhibit.blacklight_configuration.index_fields['foo_tesim'] =
+      exhibit.blacklight_configuration.blacklight_config.index_fields['foo_tesim'] =
         Blacklight::Configuration::IndexField.new(label: "Label", enabled: true, show: true)
       subject.save
 
       expect(subject).to be_configured_to_display
     end
     it 'should be falsey when a few has not been configured true' do
-      exhibit.blacklight_configuration.index_fields['foo_tesim'] =
+      exhibit.blacklight_configuration.blacklight_config.index_fields['foo_tesim'] =
         Blacklight::Configuration::IndexField.new(label: "Label", enabled: true, view_name: false)
       subject.save
 

--- a/spec/models/spotlight/resources/upload_spec.rb
+++ b/spec/models/spotlight/resources/upload_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Spotlight::Resources::Upload, :type => :model do
-  let(:exhibit) { FactoryGirl.create :exhibit }
+  let!(:exhibit) { FactoryGirl.create :exhibit }
+  let!(:custom_field) { FactoryGirl.create :custom_field, exhibit: exhibit }
   before do
     subject.exhibit = exhibit
   end
@@ -12,7 +13,8 @@ describe Spotlight::Resources::Upload, :type => :model do
         title: "Title Data",
         description: "Description Data",
         attribution: "Attribution Data",
-        date: "Date Data"
+        date: "Date Data",
+        custom_field.field => "Custom Field Data"
       }
       allow(subject).to receive(:url).and_return(stub_model(Spotlight::ItemUploader))
       allow(subject.url.file).to receive(:file).and_return(File.expand_path(File.join('..', 'fixtures', '800x600.png'), Rails.root))
@@ -47,6 +49,9 @@ describe Spotlight::Resources::Upload, :type => :model do
     it 'should have the full image dimensions fields' do
       expect(subject.to_solr[:spotlight_full_image_height_ssm]).to eq 600
       expect(subject.to_solr[:spotlight_full_image_width_ssm]).to eq 800
+    end
+    it 'should have fields representing exhibit specific custom fields' do
+      expect(subject.to_solr[custom_field.field]).to eq "Custom Field Data"
     end
   end
 end


### PR DESCRIPTION
Closes #852 

![custom-fields](https://cloud.githubusercontent.com/assets/96776/5751445/8f952188-9c18-11e4-8df0-36e4b544d53d.gif)
