### PR TITLE
Make configured non-repository item upload fields editable

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -144,7 +144,20 @@ class Spotlight::CatalogController < ::CatalogController
   end
 
   def solr_document_params
-    params.require(:solr_document).permit(:exhibit_tag_list, sidecar: { data: [custom_field_params] })
+    params.require(:solr_document).permit(:exhibit_tag_list, sidecar: { data: [editable_solr_document_params] })
+  end
+
+  def editable_solr_document_params
+    custom_field_params + uploaded_resource_params
+  end
+
+  def uploaded_resource_params
+    if @document.uploaded_resource?
+      return Spotlight::Resources::Upload.fields(current_exhibit).collect do |_, config|
+        config.solr_field
+      end
+    end
+    []
   end
 
   def custom_field_params

--- a/app/models/concerns/spotlight/solr_document.rb
+++ b/app/models/concerns/spotlight/solr_document.rb
@@ -17,9 +17,7 @@ module Spotlight
       after_save :reindex
 
       ::SolrDocument.use_extension(Spotlight::SolrDocument::UploadedResource) do |document|
-        document[Spotlight::Engine.config.full_image_field].present? &&
-        document[:spotlight_resource_type_ssm].present? &&
-        document[:spotlight_resource_type_ssm].include?("spotlight/resources/uploads")
+        document.uploaded_resource?
       end
     end
     
@@ -78,6 +76,12 @@ module Spotlight
 
     def public? exhibit
       sidecar(exhibit).public?
+    end
+
+    def uploaded_resource?
+      self[Spotlight::Engine.config.full_image_field].present? &&
+      self[:spotlight_resource_type_ssm].present? &&
+      self[:spotlight_resource_type_ssm].include?("spotlight/resources/uploads")
     end
 
     def attribute_present? *args

--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -1,4 +1,4 @@
-<%= bootstrap_form_for @document, url: spotlight.exhibit_catalog_path(current_exhibit, @document), html: {:'data-form-observer' => true} do |f| %>
+<%= bootstrap_form_for document, url: spotlight.exhibit_catalog_path(current_exhibit, document), html: {:'data-form-observer' => true} do |f| %>
 <div class="edit-fields">
   <%= f.fields_for :sidecar do |c| %>
     <%= c.fields_for :data do |d| %>
@@ -14,6 +14,11 @@
           <% end %>
         </div>
       <% end %>
+      <% if document.uploaded_resource? %>
+        <% Spotlight::Resources::Upload.fields(current_exhibit).each do |label, config| %>
+          <%= d.send((config.form_field_type || :text_field), config.solr_field, value: document.first(config.solr_field), label: label.to_s.titleize) %>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 
@@ -22,7 +27,7 @@
   </div>
   <div class="form-actions">
     <div class="primary-actions">
-      <%= cancel_link @document, spotlight.exhibit_catalog_path(current_exhibit, @document), class: 'btn btn-link' %>
+      <%= cancel_link document, spotlight.exhibit_catalog_path(current_exhibit, document), class: 'btn btn-link' %>
       <%= f.submit nil, class: 'btn btn-primary' %>
       </div>
   </div>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -117,4 +117,28 @@ describe SolrDocument, :type => :model do
       expect(subject).to be_private exhibit
     end
   end
+
+  describe 'uploaded resources' do
+    let(:uploaded_resource) {
+      SolrDocument.new(
+        Spotlight::Engine.config.full_image_field => "ImageData",
+        spotlight_resource_type_ssm: "spotlight/resources/uploads"
+      )
+    }
+    it 'should not include Spotlight::SolrDocument::UploadedResource when the correct fields are present' do
+      expect(subject).to_not be_kind_of Spotlight::SolrDocument::UploadedResource
+    end
+    it 'should include Spotlight::SolrDocument::UploadedResource when the correct fields are present' do
+      expect(uploaded_resource).to be_kind_of Spotlight::SolrDocument::UploadedResource
+    end
+    describe '#uploaded_resource?' do
+      it 'should return false if the correct fields are not present' do
+        expect(subject).to_not be_uploaded_resource
+      end
+      it 'should return true when the correct fields are present' do
+        expect(uploaded_resource).to be_uploaded_resource
+      end
+    end
+  end
+
 end

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -65,9 +65,6 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_geographic_ssim', :label => 'Geographic' 
     config.add_facet_field 'subject_temporal_ssim', :label => 'Era'  
     config.add_facet_field 'language_ssim', :label => 'Language'  
-    config.add_index_field Spotlight::Engine.config.uploaded_description_field, :label => 'Description'
-    config.add_index_field Spotlight::Engine.config.uploaded_attribution_field, :label => 'Attribution'
-    config.add_index_field Spotlight::Engine.config.uploaded_date_field, :label => 'Date'
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -82,6 +79,9 @@ class CatalogController < ApplicationController
     config.add_index_field 'note_source_tesim', :label => 'Source'
     config.add_index_field 'subject_geographic_tesim', :label => 'Geographic Subject'
     config.add_index_field 'subject_temporal_tesim', :label => 'Temporal Subject'
+    config.add_index_field Spotlight::Engine.config.uploaded_description_field, :label => 'Description'
+    config.add_index_field Spotlight::Engine.config.uploaded_attribution_field, :label => 'Attribution'
+    config.add_index_field Spotlight::Engine.config.uploaded_date_field, :label => 'Date'
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display 

--- a/spec/views/spotlight/catalog/_edit_default.html.erb_spec.rb
+++ b/spec/views/spotlight/catalog/_edit_default.html.erb_spec.rb
@@ -1,20 +1,43 @@
 require 'spec_helper'
 
 describe "spotlight/catalog/_edit_default.html.erb", :type => :view do
-  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:blacklight_config) {
+    Blacklight::Configuration.new do |config|
+      config.index.title_field = :title_field
+    end
+  }
 
   let(:document) { stub_model(::SolrDocument) }
 
+  let(:exhibit) { stub_model(Spotlight::Exhibit) }
+
   before do
+    allow(exhibit).to receive_messages(blacklight_config: blacklight_config)
+
     allow(view).to receive_messages(exhibit_tags_path: "autocomplete-path.json")
     allow(view).to receive_messages(blacklight_config: blacklight_config)
-    allow(view).to receive_messages(current_exhibit: stub_model(Spotlight::Exhibit))
-    assign(:document, document)
+    allow(view).to receive_messages(current_exhibit: exhibit)
+    allow(view).to receive_messages(document: document)
   end
 
   it "should have a edit tag form" do
     render
     expect(rendered).to have_field 'solr_document_exhibit_tag_list'
     expect(rendered).to have_selector '#solr_document_exhibit_tag_list[@data-autocomplete_url="autocomplete-path.json"]'
+  end
+  it 'should not have special metadata editing fields for non-uploaded resources' do
+    render
+    expect(rendered).to_not have_field 'Title'
+    expect(rendered).to_not have_field 'Description'
+    expect(rendered).to_not have_field 'Attribution'
+    expect(rendered).to_not have_field 'Date'
+  end
+  it 'should have special metadata fields for an uploaded resource' do
+    allow(document).to receive_messages(:uploaded_resource? => true)
+    render
+    expect(rendered).to have_field 'Title'
+    expect(rendered).to have_field 'Description'
+    expect(rendered).to have_field 'Attribution'
+    expect(rendered).to have_field 'Date'
   end
 end


### PR DESCRIPTION
Closes #841

![edit-uploaded-fields](https://cloud.githubusercontent.com/assets/96776/5786757/35cfe254-9d9f-11e4-833f-63baf40f9107.png)
