### PR TITLE
Make repository items a config option for implementations to override

### DIFF
--- a/app/views/spotlight/catalog/_admin_header.html.erb
+++ b/app/views/spotlight/catalog/_admin_header.html.erb
@@ -1,6 +1,8 @@
 <div class="add-items-nav clearfix">
   <div class="pull-right">
-    <%= link_to t('.new.repo_item'), new_exhibit_catalog_path(current_exhibit), class: 'btn btn-default' %>
+    <% if Spotlight::Engine.config.new_resource_partials.any? %>
+      <%= link_to t('.new.repo_item'), new_exhibit_catalog_path(current_exhibit), class: 'btn btn-default' %>
+    <% end %>
     <%= link_to t('.new.non_repo_item'), new_exhibit_resources_upload_path(current_exhibit), class: 'btn btn-default' %>
   </div>
 </div>

--- a/app/views/spotlight/catalog/new.html.erb
+++ b/app/views/spotlight/catalog/new.html.erb
@@ -1,10 +1,7 @@
 <%= render 'spotlight/shared/curation_sidebar' %>
 <div id="content" class="col-md-9">
   <%= curation_page_title %>
-
-  <div class="clearfix">
-    <%= render 'spotlight/resources/bookmarklet' %>
-  </div>
-
-  <%= render 'spotlight/resources/csv/form' %>
+  <% Spotlight::Engine.config.new_resource_partials.each do |p| %>
+    <%= render p %>
+  <% end %>
 </div>

--- a/app/views/spotlight/resources/_bookmarklet.html.erb
+++ b/app/views/spotlight/resources/_bookmarklet.html.erb
@@ -1,4 +1,4 @@
-<div class="col-md-12">
+<div>
 <p><%= t(:'.instructions') %></p>
 
 <%= link_to t(:'.bookmarklet', application_name: application_name), "javascript:var q=document.location; void(open('#{new_exhibit_resource_url(current_exhibit) }?popup=true&resource[url]='+encodeURIComponent(q),'#{ application_name }','toolbar=no,width=700,height=350'));", class: 'btn btn-default', onclick: "return false;" %>

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -35,6 +35,7 @@ module Spotlight
     end
 
     Spotlight::Engine.config.resource_providers = []
+    Spotlight::Engine.config.new_resource_partials = [] # e.g. "spotlight/resources/bookmarklet"
 
     # The allowed file extensions for uploading non-repository items.
     Spotlight::Engine.config.allowed_upload_extensions = %w(jpg jpeg png)

--- a/spec/features/add_item_bookmarklet_spec.rb
+++ b/spec/features/add_item_bookmarklet_spec.rb
@@ -6,6 +6,10 @@ describe "adding an item using the provided bookmarklet", :type => :feature do
   let(:search) { exhibit.searches.first }
   before { login_as curator }
 
+  before do
+    Spotlight::Engine.config.new_resource_partials += ["spotlight/resources/bookmarklet"]
+  end
+
   it "should have an exhibit-specific bookmarklet" do
     visit spotlight.admin_exhibit_catalog_index_path(exhibit)
     click_link "Add repository item"

--- a/spec/views/spotlight/catalog/admin.html.erb_spec.rb
+++ b/spec/views/spotlight/catalog/admin.html.erb_spec.rb
@@ -10,14 +10,26 @@ module Spotlight
       allow(view).to receive(:new_exhibit_catalog_path).and_return('')
       allow(view).to receive(:new_exhibit_resources_upload_path).and_return('')
       assign(:exhibit, exhibit)
-    end
-    it "should render the sidebar" do
       assign(:response, [])
       stub_template '_search_header.html.erb' => 'header'
       stub_template '_zero_results.html.erb' => 'nuffin'
       stub_template '_results_pagination.html.erb' => '0'
+    end
+    it "should render the sidebar" do
       render
       expect(rendered).to have_link 'Browse'
+    end
+
+    it "should not render the 'add repository item' link if no repository sources are configured" do
+      allow(Spotlight::Engine.config).to receive(:new_resource_partials).and_return([])
+      render
+      expect(rendered).to_not have_link "Add repository item"
+    end
+
+    it "should not render the 'add repository item' link if no repository sources are configured" do
+      allow(Spotlight::Engine.config).to receive(:new_resource_partials).and_return(['a'])
+      render
+      expect(rendered).to have_link "Add repository item"
     end
   end
 end

--- a/spec/views/spotlight/catalog/new.html.erb_spec.rb
+++ b/spec/views/spotlight/catalog/new.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe "spotlight/catalog/new.html.erb", :type => :view do
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:exhibit) { stub_model(Spotlight::Exhibit)}
+
+  before do
+    allow(view).to receive_messages(blacklight_config: blacklight_config)
+    allow(view).to receive(:current_exhibit).and_return(exhibit)
+    allow(view).to receive_messages(current_page?: true)
+    stub_template 'spotlight/shared/_curation_sidebar.html.erb' => ''
+  end
+
+  it "should render the configured partials" do
+    allow(Spotlight::Engine.config).to receive(:new_resource_partials).and_return(['a', 'b', 'c'])
+    stub_template '_a.html.erb' => 'a_template'
+    stub_template '_b.html.erb' => 'b_template'
+    stub_template '_c.html.erb' => 'c_template'
+    render
+    expect(rendered).to have_content "a_template"
+    expect(rendered).to have_content "b_template"
+    expect(rendered).to have_content "c_template"
+  end
+
+  
+end


### PR DESCRIPTION
Part of #846. After this, downstream applications can implement whatever type of form they want.