### PR TITLE
Add multiple non-repository item upload via CSV.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ env:
   global:
     - JRUBY_OPTS="-J-Xms512m -J-Xmx1024m"
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-  matrix:
-    - "RAILS_VERSION=4.1.8"
-    - "RAILS_VERSION=4.2.0"
 
 sudo: false
 language: ruby

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -153,9 +153,7 @@ class Spotlight::CatalogController < ::CatalogController
 
   def uploaded_resource_params
     if @document.uploaded_resource?
-      return Spotlight::Resources::Upload.fields(current_exhibit).collect do |_, config|
-        config.solr_field
-      end
+      return Spotlight::Resources::Upload.fields(current_exhibit).collect(&:solr_field)
     end
     []
   end

--- a/app/jobs/spotlight/add_uploads_from_csv.rb
+++ b/app/jobs/spotlight/add_uploads_from_csv.rb
@@ -3,7 +3,8 @@ module Spotlight
     queue_as :default
 
     after_perform do |job|
-      Spotlight::IndexingCompleteMailer.documents_indexed(job.arguments[0], job.arguments[1], job.arguments[2]).deliver_now
+      csv_data, exhibit, user = job.arguments
+      Spotlight::IndexingCompleteMailer.documents_indexed(csv_data, exhibit, user).deliver_now
     end
 
     def perform(csv_data, exhibit, user)

--- a/app/jobs/spotlight/add_uploads_from_csv.rb
+++ b/app/jobs/spotlight/add_uploads_from_csv.rb
@@ -1,0 +1,22 @@
+module Spotlight
+  class AddUploadsFromCSV < ActiveJob::Base
+    queue_as :default
+
+    after_perform do |job|
+      Spotlight::IndexingCompleteMailer.documents_indexed(job.arguments[0], job.arguments[1], job.arguments[2]).deliver_now
+    end
+
+    def perform(csv_data, exhibit, user)
+      csv_data.each do |row|
+        if (url = row.delete("url")).present?
+          Spotlight::Resources::Upload.create(
+            remote_url_url: url,
+            data: row,
+            exhibit: exhibit
+          )
+        end
+      end
+
+    end
+  end
+end

--- a/app/mailers/spotlight/indexing_complete_mailer.rb
+++ b/app/mailers/spotlight/indexing_complete_mailer.rb
@@ -1,0 +1,10 @@
+module Spotlight
+  class IndexingCompleteMailer < ActionMailer::Base
+
+    def documents_indexed(csv_data, exhibit, user)
+      @number = csv_data.length
+      @exhibit = exhibit
+      mail(to: user.email, subject: "Document indexing complete")
+    end
+  end
+end

--- a/app/models/spotlight/resources/csv_upload.rb
+++ b/app/models/spotlight/resources/csv_upload.rb
@@ -1,0 +1,7 @@
+module Spotlight
+  class Resources::CsvUpload
+    attr_reader :url
+    include ActiveModel::Model
+    extend ActiveModel::Translation
+  end
+end

--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -15,8 +15,8 @@
         </div>
       <% end %>
       <% if document.uploaded_resource? %>
-        <% Spotlight::Resources::Upload.fields(current_exhibit).each do |label, config| %>
-          <%= d.send((config.form_field_type || :text_field), config.solr_field, value: document.first(config.solr_field), label: label.to_s.titleize) %>
+        <% Spotlight::Resources::Upload.fields(current_exhibit).each do |config| %>
+          <%= d.send((config.form_field_type || :text_field), config.solr_field, value: document.first(config.solr_field), label: current_exhibit.blacklight_config.index_fields[config.solr_field.to_s].try(:label) || t(".#{config.solr_field}")) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/spotlight/indexing_complete_mailer/documents_indexed.html.erb
+++ b/app/views/spotlight/indexing_complete_mailer/documents_indexed.html.erb
@@ -1,0 +1,3 @@
+<p>Your CSV file has just finished being processed.</p>
+
+<p><%= @number %> documents have been indexed from the CSV file and added to the exhibit <%= @exhibit.title %>.</p>

--- a/app/views/spotlight/indexing_complete_mailer/documents_indexed.html.erb
+++ b/app/views/spotlight/indexing_complete_mailer/documents_indexed.html.erb
@@ -1,3 +1,3 @@
-<p>Your CSV file has just finished being processed.</p>
+<p><%= t :".title" %></p>
 
-<p><%= @number %> documents have been indexed from the CSV file and added to the exhibit <%= @exhibit.title %>.</p>
+<p><%= t :".body", count: @number, title: @exhibit.title %></p>

--- a/app/views/spotlight/resources/upload/_multi_item_form.html.erb
+++ b/app/views/spotlight/resources/upload/_multi_item_form.html.erb
@@ -1,0 +1,9 @@
+<%= bootstrap_form_for([current_exhibit, @resource.becomes(Spotlight::Resources::CsvUpload)], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-6 col-md-6', html: { class: 'item-upload-form', multipart: true } ) do |f| %>
+  <%= f.url_field :url, type: "file", help: t('.help_html', link: link_to(t('.template'), template_exhibit_resources_uploads_path)), label: t('.file_label') %>
+  <div class="form-actions">
+    <div class="primary-actions">
+      <%= cancel_link @resource, :back, class: 'btn btn-default' %>
+      <%= f.submit t('.add_item'), class: 'btn btn-primary' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/spotlight/resources/upload/_single_item_form.html.erb
+++ b/app/views/spotlight/resources/upload/_single_item_form.html.erb
@@ -1,8 +1,8 @@
 <%= bootstrap_form_for([current_exhibit, @resource.becomes(Spotlight::Resources::Upload)], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-6 col-md-6', html: { class: 'item-upload-form', multipart: true } ) do |f| %>
   <%= f.url_field :url, type: "file", help: t('.url-field.help', extensions: Spotlight::Engine.config.allowed_upload_extensions.join(' ')), label: "File" %>
   <%= f.fields_for :data do |d| %>
-    <% Spotlight::Resources::Upload.fields(current_exhibit).each do |field, config| %>
-      <%= d.send((config.form_field_type || :text_field), field) %>
+    <% Spotlight::Resources::Upload.fields(current_exhibit).each do |config| %>
+      <%= d.send((config.form_field_type || :text_field), config.solr_field, label: current_exhibit.blacklight_config.index_fields[config.solr_field.to_s].try(:label) || t(".#{config.solr_field}")) %>
     <% end %>
     <% current_exhibit.custom_fields.each do |custom_field| %>
       <%= d.text_field custom_field.field, label: custom_field.label %>

--- a/app/views/spotlight/resources/upload/new.html.erb
+++ b/app/views/spotlight/resources/upload/new.html.erb
@@ -6,7 +6,7 @@
       <li role="presentation" class="active">
         <a href="#single" aria-controls="single" role="tab" data-toggle="tab"><%= t('.single') %></a>
       </li>
-      <li role="presentation" class="disabled">
+      <li role="presentation">
         <a href="#multi" aria-controls="multi" role="tab" data-toggle="tab"><%= t('.multiple') %></a>
       </li>
     </ul>

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 4.0", ">= 4.0.1"
+  s.add_dependency "rails", "~> 4.0", ">= 4.2.0"
   s.add_dependency "blacklight", "~> 5.8.0"
   s.add_dependency "autoprefixer-rails", "< 5.0.0"
   s.add_dependency "cancancan"

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -419,6 +419,12 @@ en:
     shared:
       report_a_problem:
         title: Contact Us
+    indexing_complete_mailer:
+      documents_indexed:
+        title: "Your CSV file has just finished being processed."
+        body:
+          one: "%{count} document has been indexed from the CSV file and added to the exhibit %{title}."
+          other: "%{count} documents have been indexed from the CSV file and added to the exhibit %{title}."
   shared:
     exhibit_masthead:
       more_exhibits: More Exhibits

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -184,6 +184,7 @@ en:
         index: 'Search Results'
       edit_default:
         blank_field_warning_html: "This field is currently hidden on all pages. You can make it visible on the Curation &gt; %{link} page."
+        full_title_tesim: "Title"
       facets:
         exhibit_visibility:
           label: "Item Visibility"
@@ -341,15 +342,23 @@ en:
         form:
           template: "Download Template"
       upload:
+        csv:
+          success: "'%{file_name}' has been uploaded.  An email will be sent to you once indexing is complete."
         new:
           header: "Add non-repository items"
           single: "Single item"
           multiple: "Multiple items using CSV file"
         error: "There was a problem uploading your object."
+        multi_item_form:
+          add_item: "Add item"
+          help_html: "%{link}"
+          template: "Download template"
+          file_label: "CSV File"
         success: "Object uploaded successfully."
         single_item_form:
           add_item: "Add item"
           add_item_and_continue: "Add item and continue adding"
+          full_title_tesim: "Title"
           url-field:
             help: "Valid file types: %{extensions}"
       bookmarklet:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,13 @@ Spotlight::Engine.routes.draw do
 
     resources :resources
 
-    resources :resources_uploads, controller: 'resources/upload', path: 'upload_resources'
+    post :csv_uploads, to: "resources/upload#csv_upload", path: 'upload_resources/csv_upload', as: :resources_csv_uploads
+
+    resources :resources_uploads, controller: 'resources/upload', path: 'upload_resources' do
+      collection do
+        get :template
+      end
+    end
 
     resources :resources_csvs, controller: 'resources/csv', path: 'csv_resources' do
       collection do

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -56,11 +56,11 @@ module Spotlight
     Spotlight::Engine.config.uploaded_attribution_field = :spotlight_upload_attribution_tesim
     Spotlight::Engine.config.uploaded_date_field = :spotlight_upload_date_tesim
 
-    Spotlight::Engine.config.upload_fields = {
-      description: OpenStruct.new(solr_field: Spotlight::Engine.config.uploaded_description_field, form_field_type: :text_area),
-      attribution: OpenStruct.new(solr_field: Spotlight::Engine.config.uploaded_attribution_field),
-      date:        OpenStruct.new(solr_field: Spotlight::Engine.config.uploaded_date_field)
-    }
+    Spotlight::Engine.config.upload_fields = [
+      OpenStruct.new(solr_field: Spotlight::Engine.config.uploaded_description_field, form_field_type: :text_area),
+      OpenStruct.new(solr_field: Spotlight::Engine.config.uploaded_attribution_field),
+      OpenStruct.new(solr_field: Spotlight::Engine.config.uploaded_date_field)
+    ]
 
     Blacklight::Engine.config.inject_blacklight_helpers = false
     

--- a/spec/features/upload_non_repository_item_spec.rb
+++ b/spec/features/upload_non_repository_item_spec.rb
@@ -11,14 +11,23 @@ describe "Uploading a non-repository item", :type => :feature do
       visit spotlight.new_exhibit_resources_upload_path(exhibit)
       expect(page).to have_css("h1", text: /Curation/)
       expect(page).to have_css "h1 small", text: "Add non-repository items"
-      within("form.item-upload-form") do
+      within("form#new_resources_upload") do
         expect(page).to have_css('#resources_upload_url[type="file"]')
         expect(page).to have_css('.help-block', text: 'Valid file types: jpg jpeg png')
-        expect(page).to have_css('#resources_upload_data_title[type="text"]')
-        expect(page).to have_css('textarea#resources_upload_data_description')
-        expect(page).to have_css('#resources_upload_data_attribution[type="text"]')
-        expect(page).to have_css('#resources_upload_data_date[type="text"]')
+        expect(page).to have_css('#resources_upload_data_full_title_tesim[type="text"]')
+        expect(page).to have_css('textarea#resources_upload_data_spotlight_upload_description_tesim')
+        expect(page).to have_css('#resources_upload_data_spotlight_upload_attribution_tesim[type="text"]')
+        expect(page).to have_css('#resources_upload_data_spotlight_upload_date_tesim[type="text"]')
         expect(page).to have_css("#resources_upload_data_#{custom_field.field}[type='text']")
+      end
+    end
+    it "should display the multi-item CSV upload form" do
+      visit spotlight.new_exhibit_resources_upload_path(exhibit)
+      expect(page).to have_css("h1", text: /Curation/)
+      expect(page).to have_css "h1 small", text: "Add non-repository items"
+      within("form#new_resources_csv_upload") do
+        expect(page).to have_css('#resources_csv_upload_url[type="file"]')
+        expect(page).to have_css('.help-block a', text: 'Download template')
       end
     end
   end

--- a/spec/fixtures/csv-upload-fixture.csv
+++ b/spec/fixtures/csv-upload-fixture.csv
@@ -1,0 +1,1 @@
+url,full_title_tesim,spotlight_upload_description_tesim,spotlight_upload_attribution_tesim,spotlight_upload_date_tesimhttp://lorempixel.com/800/500/,A random image,A random 800 by 500 image from lorempixel,lorempixel.com,2015http://lorempixel.com/900/600/,Another random image,A random 900 by 600 image from lorempixel,lorempixel.com,2014

--- a/spec/mailers/spotlight/indexing_complete_mailer_spec.rb
+++ b/spec/mailers/spotlight/indexing_complete_mailer_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Spotlight::IndexingCompleteMailer do
+  let(:user) { double(email: "test@example.com") }
+  let(:exhibit) { double(title: "Exhibit title") }
+  subject { Spotlight::IndexingCompleteMailer.documents_indexed [1,2,3], exhibit, user}
+  
+  it 'renders the receiver email' do
+    expect(subject.to).to eql([user.email])
+  end
+
+  it "includes a title" do
+    expect(subject.body.encoded).to match "Your CSV file has just finished being processed"
+  end
+  
+  it 'describes how many documents were indexed' do
+    expect(subject.body.encoded).to match "3 documents"
+  end
+
+  context "single item" do
+    subject { Spotlight::IndexingCompleteMailer.documents_indexed [1], exhibit, user}
+
+    it 'handles pluralization when only a single item was indexed' do
+      expect(subject.body.encoded).to match "1 document has"
+    end
+  end
+  
+  it 'includes the exhibit title' do
+    expect(subject.body.encoded).to match exhibit.title
+  end
+end

--- a/spec/models/spotlight/resources/upload_spec.rb
+++ b/spec/models/spotlight/resources/upload_spec.rb
@@ -10,10 +10,10 @@ describe Spotlight::Resources::Upload, :type => :model do
     before do
       subject.id = "1"
       subject.data = {
-        title: "Title Data",
-        description: "Description Data",
-        attribution: "Attribution Data",
-        date: "Date Data",
+        configured_title_field: "Title Data",
+        spotlight_upload_description_tesim: "Description Data",
+        spotlight_upload_attribution_tesim: "Attribution Data",
+        spotlight_upload_date_tesim: "Date Data",
         custom_field.field => "Custom Field Data"
       }
       allow(subject).to receive(:url).and_return(stub_model(Spotlight::ItemUploader))


### PR DESCRIPTION
Closes #888

This refactors a bunch of the upload class and therefore will unfortunately be totally clobbered by #891.

![csv-upload](https://cloud.githubusercontent.com/assets/96776/5881641/4216c0de-a2f7-11e4-9daf-6b705977dba9.gif)
