### PR TITLE
Image versions field

### DIFF
--- a/app/models/spotlight/resources/upload.rb
+++ b/app/models/spotlight/resources/upload.rb
@@ -66,7 +66,8 @@ module Spotlight
 
     def add_file_versions solr_hash
       Spotlight::ItemUploader.configured_versions.each do |config|
-        solr_hash[exhibit.blacklight_config.index.send(config[:blacklight_config_field])] = url.send(config[:version]).url
+        field = exhibit.blacklight_config.index.send(config[:blacklight_config_field])
+        solr_hash[field] = url.send(config[:version]).url if field
       end
     end
 

--- a/app/models/spotlight/resources/upload.rb
+++ b/app/models/spotlight/resources/upload.rb
@@ -39,7 +39,7 @@ module Spotlight
     
     def add_default_solr_fields solr_hash
       solr_hash[exhibit.blacklight_config.solr_document_model.unique_key.to_sym] = compound_id
-      solr_hash[exhibit.blacklight_config.index.full_image_field] = url.url
+      solr_hash[Spotlight::Engine.config.full_image_field] = url.url
     end
 
     def add_image_dimensions solr_hash
@@ -66,8 +66,7 @@ module Spotlight
 
     def add_file_versions solr_hash
       Spotlight::ItemUploader.configured_versions.each do |config|
-        field = exhibit.blacklight_config.index.send(config[:blacklight_config_field])
-        solr_hash[field] = url.send(config[:version]).url if field
+        solr_hash[config[:field]] = url.send(config[:version]).url
       end
     end
 

--- a/app/uploaders/spotlight/configurable_uploader_versions.rb
+++ b/app/uploaders/spotlight/configurable_uploader_versions.rb
@@ -10,7 +10,7 @@ module Spotlight
       @configured_versions ||= [
         {
           version: :thumb,
-          blacklight_config_field: :thumbnail_field,
+          field: Spotlight::Engine.config.try(:thumbnail_field),
           lambda: lambda {
             version :thumb do
               process :resize_to_fit => [400,400]
@@ -19,14 +19,14 @@ module Spotlight
         },
         {
           version: :square,
-          blacklight_config_field: :square_image_field,
+          field: Spotlight::Engine.config.try(:square_image_field),
           lambda: lambda {
             version :square do
               process :resize_to_fill => [100,100]
             end
           }
         }
-      ]
+      ].reject{|v| v[:field].blank? }
     end
   end
 end

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -51,6 +51,8 @@ module Spotlight
 
     # The solr field that original (largest) images will be stored.
     Spotlight::Engine.config.full_image_field = :full_image_url_ssm
+    Spotlight::Engine.config.thumbnail_field = :thumbnail_url_ssm
+    Spotlight::Engine.config.square_image_field = :thumbnail_square_url_ssm
 
     Spotlight::Engine.config.uploaded_description_field = :spotlight_upload_description_tesim
     Spotlight::Engine.config.uploaded_attribution_field = :spotlight_upload_attribution_tesim

--- a/spec/models/spotlight/resources/upload_spec.rb
+++ b/spec/models/spotlight/resources/upload_spec.rb
@@ -21,9 +21,6 @@ describe Spotlight::Resources::Upload, :type => :model do
       allow(subject.exhibit).to receive(:blacklight_config).and_return(
         Blacklight::Configuration.new do |config|
           config.index.title_field = :configured_title_field
-          config.index.full_image_field = :configured_full_image_field
-          config.index.thumbnail_field = :configured_thumbnail_field
-          config.index.square_image_field = :configured_square_field
         end
       )
     end
@@ -42,9 +39,9 @@ describe Spotlight::Resources::Upload, :type => :model do
       expect(subject.to_solr[:spotlight_resource_type_ssim]).to eq 'spotlight/resources/uploads'
     end
     it 'should have the various image fields' do
-      expect(subject.to_solr).to have_key :configured_full_image_field
-      expect(subject.to_solr).to have_key :configured_thumbnail_field
-      expect(subject.to_solr).to have_key :configured_square_field
+      expect(subject.to_solr).to have_key Spotlight::Engine.config.full_image_field
+      expect(subject.to_solr).to have_key Spotlight::Engine.config.thumbnail_field
+      expect(subject.to_solr).to have_key Spotlight::Engine.config.square_image_field
     end
     it 'should have the full image dimensions fields' do
       expect(subject.to_solr[:spotlight_full_image_height_ssm]).to eq 600

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -28,9 +28,7 @@ class CatalogController < ApplicationController
     # solr field configuration for search results/index views
     config.index.title_field = 'full_title_tesim'
     config.index.display_type_field = 'content_metadata_type_ssm'
-    config.index.full_image_field = Spotlight::Engine.config.full_image_field
-    config.index.thumbnail_field = :thumbnail_url_ssm
-    config.index.square_image_field = :thumbnail_square_url_ssm
+    config.index.thumbnail_field = Spotlight::Engine.config.thumbnail_field
 
     config.view.gallery.partials = [:index_header, :index]
     config.view.slideshow.partials = [:index]


### PR DESCRIPTION
@jkeck can you look at  90c8b54? @snydman was running into this problem in -prod because we hadn't configured a square field. Should we just invent a default? Should we define derivates in some other way?