### PR TITLE
Fixes edit screen inconsistencies

### DIFF
--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -24,7 +24,7 @@ module Spotlight::MainAppHelpers
   end
   
   def field_enabled? field, *args
-    field.enabled && field.send((:show if controller.is_a? Blacklight::Catalog and action_name == "show") || document_index_view_type)
+    field.enabled && field.send((:show if controller.is_a? Blacklight::Catalog and ["edit", "show"].include?(action_name)) || document_index_view_type)
   end
 
 end

--- a/app/views/spotlight/catalog/edit.html.erb
+++ b/app/views/spotlight/catalog/edit.html.erb
@@ -1,1 +1,3 @@
-<%= render_document_partials @document, blacklight_config.view_config(:edit).partials %>
+<div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
+  <%= render_document_partials @document, blacklight_config.view_config(:edit).partials %>
+</div>

--- a/spec/helpers/spotlight/main_app_helpers_spec.rb
+++ b/spec/helpers/spotlight/main_app_helpers_spec.rb
@@ -29,4 +29,24 @@ describe Spotlight::MainAppHelpers, :type => :helper do
       its(:show_contact_form?) { should be_falsey }
     end
   end
+
+  describe '#field_enabled?' do
+    let(:field) { FactoryGirl.create(:custom_field) }
+    let(:controller) { OpenStruct.new }
+    before do
+      controller.extend(Blacklight::Catalog)
+      allow(helper).to receive(:controller).and_return(controller)
+      allow(helper).to receive(:document_index_view_type).and_return(nil)
+      allow(field).to receive(:enabled).and_return(true)
+      allow(field).to receive(:show).and_return(:value)
+    end
+    it 'should return the value of field#show if the action_name is "show"' do
+      allow(helper).to receive(:action_name).and_return("show")
+      expect(helper.field_enabled?(field)).to eq :value
+    end
+    it 'should return the value of field#show if the action_name is "edit"' do
+      allow(helper).to receive(:action_name).and_return("edit")
+      expect(helper.field_enabled?(field)).to eq :value
+    end
+  end
 end

--- a/spec/views/spotlight/catalog/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/catalog/edit.html.erb_spec.rb
@@ -9,12 +9,13 @@ describe "spotlight/catalog/edit.html.erb", :type => :view do
     allow(view).to receive_messages(blacklight_config: blacklight_config)
     allow(view).to receive_messages(current_exhibit: stub_model(Spotlight::Exhibit))
     assign(:document, document)
+    allow(view).to receive(:document_counter)
+    allow(view).to receive(:render_document_partials)
+    render
   end
 
-  before do
-    allow(view).to receive_messages(current_page?: true)
-    allow(view).to receive(:document_show_html_title)
-    allow(view).to receive(:edit_exhibit_catalog_path)
+  it 'should render a document div' do
+    expect(rendered).to have_css "#document.document"
   end
 end
 


### PR DESCRIPTION
Closes #889 

- [x] Adds div around edit partials similar to the div on around show partials (fixes OSD styling)
- [x] Allow for `field#show` to be called when under a `Blacklight::Catalog` controller in the `show` or `edit` actions. (fixes custom fields metadata not displaying on the edit screen)

## Before
![before-trending-cats](https://cloud.githubusercontent.com/assets/96776/5930328/fe05ee70-a642-11e4-94b0-faeae7274f8d.png)

## After
![after-trending-cats](https://cloud.githubusercontent.com/assets/96776/5930329/fe07dcda-a642-11e4-836a-6ca70dd76bfb.png)
