### PR TITLE
Add twitter:card metadata for the exhibit home page with the title, subt...

### DIFF
--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -71,6 +71,7 @@ class Spotlight::ExhibitsController < Spotlight::ApplicationController
       :subtitle,
       :description,
       :published,
+      :featured_image,
       contact_emails_attributes: [:id, :email]
     )
   end

--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -114,6 +114,27 @@ module Spotlight
       )
     end
 
+    def add_exhibit_twitter_card_content
+      twitter_card('summary') do |card|
+        card.url exhibit_root_url(current_exhibit)
+        card.title current_exhibit.title
+        card.description current_exhibit.subtitle
+        card.image carrierwave_url(current_exhibit.featured_image) if current_exhibit.featured_image
+      end
+    end
+
+    def carrierwave_url upload
+      # Carrierwave's #url returns either a full url (if asset path was configured)
+      # or just the path to the image. We'll try to normalize it to a url.
+      url = upload.url
+
+      if url.nil? or url.starts_with? "http"
+        url
+      else
+        (Rails.application.config.asset_host || root_url).sub(/\/$/, "") + url
+      end
+    end
+
     private
 
     def main_app_url_helper?(method)

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -47,6 +47,8 @@ class Spotlight::Exhibit < ActiveRecord::Base
   after_create :initialize_main_navigation
   before_save :sanitize_description
 
+  mount_uploader :featured_image, Spotlight::FeaturedImageUploader
+
   after_destroy do
     # Touch the default exhibit to ensure caching knows that
     # the exhibits have changed.

--- a/app/uploaders/spotlight/featured_image_uploader.rb
+++ b/app/uploaders/spotlight/featured_image_uploader.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+class Spotlight::FeaturedImageUploader < CarrierWave::Uploader::Base
+
+  storage :file
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+end

--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -18,7 +18,10 @@
     <%= stylesheet_link_tag    "application" %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
-    <%= content_for(:head) %> 
+    <%= content_for(:head) %>
+    <%= description %>
+    <%= twitter_card %>
+    <%= opengraph %>
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>

--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -1,0 +1,28 @@
+<%= bootstrap_form_for @exhibit, url: ((spotlight.exhibit_path(@exhibit) if @exhibit.persisted?) || spotlight.exhibits_path), layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10', html: {class: "row"} do |f| %>
+<div class="row col-md-12">
+  <%= f.text_field :title %>
+  <%= f.text_field :subtitle %>
+  <%= f.text_area :description %>
+  <%= f.form_group(:contact_emails, label: { text: nil, class: nil }, help: nil) do %>
+  <%= f.fields_for :contact_emails do |contact| %>
+  <%= render partial: 'contact', locals: {contact: contact} %>
+  <% end %>
+  <p class="help-block"><%= t(:'.fields.contact_emails.help_block') %></p>
+  <% end %>
+  <%= f.file_field :featured_image %>
+  <%= f.form_group :featured_image_preview do %>
+    <%= image_tag @exhibit.featured_image.url %>
+  <% end %>
+  <%= f.form_group :published, label: { text: nil, class: nil }, help: nil do %>
+  <%= f.check_box :published, label: "" %>
+  <p class="help-block"><%= t(:'.fields.published.help_block') %></p>
+  <% end %>
+  
+  <div class="form-actions">
+    
+    <div class="primary-actions">
+      <%= f.submit nil, class: 'btn btn-primary' %>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/app/views/spotlight/exhibits/edit.html.erb
+++ b/app/views/spotlight/exhibits/edit.html.erb
@@ -1,30 +1,7 @@
 <%= render 'spotlight/shared/curation_sidebar' %>
 <div id="content" class="col-md-9 exhibit-admin">
   <%= administration_page_title %>
-  <%= bootstrap_form_for @exhibit, url: spotlight.exhibit_path(@exhibit), layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10', html: {class: "row"} do |f| %>
-    <div class="row col-md-12">
-      <%= f.text_field :title %>
-      <%= f.text_field :subtitle %>
-      <%= f.text_area :description %>
-      <%= f.form_group(:contact_emails, label: { text: nil, class: nil }, help: nil) do %>
-        <%= f.fields_for :contact_emails do |contact| %>
-          <%= render partial: 'contact', locals: {contact: contact} %>
-        <% end %>
-        <p class="help-block"><%= t(:'.fields.contact_emails.help_block') %></p>
-      <% end %>
-      <%= f.form_group :published, label: { text: nil, class: nil }, help: nil do %>
-        <%= f.check_box :published, label: "" %>
-        <p class="help-block"><%= t(:'.fields.published.help_block') %></p>
-      <% end %>
-
-      <div class="form-actions">
-
-        <div class="primary-actions">
-          <%= f.submit nil, class: 'btn btn-primary' %>
-        </div>
-      </div>
-    </div>
-  <% end %>
+  <%= render 'form' %>
   <div class="callout callout-danger row">
     <h4><%= t(:".delete_exhibit") %></h4>
     <p class='col-md-9'><%= t(:".delete_exhibit_warning_html", export_link: link_to(t(:'spotlight.exhibits.import.export.download'), spotlight.import_exhibit_path(@exhibit))) %></p>

--- a/app/views/spotlight/exhibits/new.html.erb
+++ b/app/views/spotlight/exhibits/new.html.erb
@@ -1,16 +1,4 @@
 <div id="content" class="col-md-9 exhibit-admin">
 <%= administration_page_title %>
-<%= bootstrap_form_for @exhibit, layout: :horizontal, label_col: 'col-md-3', control_col: 'col-sm-5' do |f| %>
-  <div class="row col-md-9">
-    <%= f.text_field :title %>
-    <%= f.text_field :subtitle %>
-    <%= f.text_area :description %>
-
-    <div class="form-actions">
-      <div class="primary-actions">
-        <%= f.submit nil, class: 'btn btn-primary' %>
-      </div>
-    </div>
-  </div>
-<% end %>
+<%= render 'form' %>
 </div>

--- a/app/views/spotlight/home_pages/_tophat.html.erb
+++ b/app/views/spotlight/home_pages/_tophat.html.erb
@@ -1,0 +1,2 @@
+<% description current_exhibit.description %>
+<% add_exhibit_twitter_card_content %>

--- a/app/views/spotlight/pages/show.html.erb
+++ b/app/views/spotlight/pages/show.html.erb
@@ -1,5 +1,5 @@
 <% set_html_page_title @page.title if @page.should_display_title? %>
-
+<% render 'tophat' %>
 <%= render 'sidebar' if @page.display_sidebar? %>
 
 <%= cache_unless current_user, @page do %>

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "underscore-rails", "~> 1.6.0"
   s.add_dependency "github-markup"
   s.add_dependency "lodash-rails"
+  s.add_dependency "tophat"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 3.1"

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -243,14 +243,15 @@ en:
       edit:
         header: Settings
         import: Import
+        delete_exhibit: Delete exhibit
+        delete_exhibit_warning_html: This action is irreversible. Be sure to back up the exhibit settings and content using the %{export_link} feature before proceeding.
+      form:
         fields:
           contact_emails:
             help_block: Each contact email will receive feedback submissions
           published:
             label: "Published"
             help_block: ""
-        delete_exhibit: Delete exhibit
-        delete_exhibit_warning_html: This action is irreversible. Be sure to back up the exhibit settings and content using the %{export_link} feature before proceeding.
       new:
         header: Create a new exhibit
       import:

--- a/db/migrate/20150127173245_add_featured_image_to_exhibit.rb
+++ b/db/migrate/20150127173245_add_featured_image_to_exhibit.rb
@@ -1,0 +1,5 @@
+class AddFeaturedImageToExhibit < ActiveRecord::Migration
+  def change
+    add_column :spotlight_exhibits, :featured_image, :string
+  end
+end

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -7,6 +7,7 @@ require 'spotlight/utils'
 require 'friendly_id'
 require 'devise'
 require 'active_model_serializers'
+require 'tophat'
 
 module Spotlight
   class Engine < ::Rails::Engine

--- a/spec/features/create_exhibit_spec.rb
+++ b/spec/features/create_exhibit_spec.rb
@@ -27,4 +27,22 @@ describe "Create a new exhibit", :type => :feature do
 
     expect(page).to have_content "The exhibit was created."
   end
+
+  it "should allow admins to include a featured image" do
+    visit '/'
+    within '.dropdown-menu' do
+      click_link "Create Exhibit"
+    end
+    
+    fill_in "Title", with: "My exhibit title"
+    attach_file('exhibit_featured_image', File.absolute_path(File.join(FIXTURES_PATH, 'avatar.png')));
+
+    click_button "Save"
+
+    expect(page).to have_content "The exhibit was created."
+    within "#exhibit-navbar" do
+      click_link "Home"
+    end
+    expect(page).to have_css "meta[name='twitter:image']", visible: false
+  end
 end

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -51,6 +51,14 @@ describe "Home page", :type => :feature do
     expect(page).to have_content "You searched for: query"
   end
 
+  it "should have <meta> tags" do
+    TopHat.current['twitter_card'] = nil
+    visit spotlight.exhibit_home_page_path(exhibit.home_page)
+
+    expect(page).to have_css "meta[name='twitter:card'][value='summary']", visible: false
+    expect(page).to have_css "meta[name='twitter:url'][value='#{spotlight.exhibit_root_url(exhibit)}']", visible: false
+  end
+
   describe "page options on edit form" do
     describe "show title" do
       let(:home_page) { FactoryGirl.create(:home_page, display_title: false, exhibit: exhibit) }

--- a/spec/helpers/spotlight/application_helper_spec.rb
+++ b/spec/helpers/spotlight/application_helper_spec.rb
@@ -104,4 +104,40 @@ describe Spotlight::ApplicationHelper, :type => :helper do
       expect(helper.render_document_class(document)).to match /blacklight-some-data/
     end
   end
+
+  describe "#add_exhibit_twitter_card_content" do
+    let(:current_exhibit) { FactoryGirl.create(:exhibit) }
+    before do
+      allow(helper).to receive_messages(current_exhibit: current_exhibit)
+      current_exhibit.subtitle = "xyz"
+      current_exhibit.description = "abc"
+      TopHat.current['twitter_card'] = nil
+    end
+
+    it "should generate a twitter card for the exhibit" do
+      allow(helper).to receive(:exhibit_root_url).and_return("some/url")
+      allow(current_exhibit).to receive(:featured_image).and_return(double(url: "http://some.host/image"))
+
+      helper.add_exhibit_twitter_card_content
+
+      card = helper.twitter_card
+      expect(card).to have_css "meta[name='twitter:card'][value='summary']", visible: false
+      expect(card).to have_css "meta[name='twitter:url'][value='some/url']", visible: false
+      expect(card).to have_css "meta[name='twitter:title'][value='#{current_exhibit.title}']", visible: false
+      expect(card).to have_css "meta[name='twitter:description'][value='#{current_exhibit.subtitle}']", visible: false
+      expect(card).to have_css "meta[name='twitter:image'][value='http://some.host/image']", visible: false
+    end
+  end
+  
+  describe "#carrierwave_url" do
+    it "should turn a application-relative URI into a path" do
+      upload = double(url: "/x/y/z")
+      expect(helper.carrierwave_url(upload)).to eq "http://test.host/x/y/z"
+    end
+
+    it "should pass a full URI through" do
+      upload = double(url: "http://some.host/x/y/z")
+      expect(helper.carrierwave_url(upload)).to eq "http://some.host/x/y/z"
+    end
+  end
 end


### PR DESCRIPTION
...itle, description, and featured image.

![screen shot 2015-01-28 at 9 35 20 am](https://cloud.githubusercontent.com/assets/111218/5943101/018eb926-a6d1-11e4-9cba-1b3f4f322132.png)

Fixes #902.

I think there's some design needed (@ggeisler) on the settings page, but I hope that can get rolled into the other theme changes we're doing.

![screen shot 2015-01-28 at 9 34 13 am](https://cloud.githubusercontent.com/assets/111218/5943079/d7d28108-a6d0-11e4-9cf9-b69da1cd3ab6.png)



