### PR TITLE
Allow for search results and records to be accessed w/o exhibit context.

### DIFF
--- a/app/assets/stylesheets/spotlight/_catalog.scss
+++ b/app/assets/stylesheets/spotlight/_catalog.scss
@@ -101,3 +101,8 @@ form.edit_solr_document {
 .edit_solr_document {
   @extend .clearfix;
 }
+
+#save-this-search {
+  float:left;
+  margin-right: $padding-xs-horizontal;
+}

--- a/app/forms/spotlight/appearance.rb
+++ b/app/forms/spotlight/appearance.rb
@@ -54,7 +54,7 @@ module Spotlight
     end
 
     def view_type_options
-      default_blacklight_config.view.keys
+      default_blacklight_config.view.select { |k,v| v.if != false }.keys
     end
 
     def per_page_options

--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -93,15 +93,6 @@ module Spotlight
       end.keys.map { |x| x.to_s }
     end
 
-    def render_save_search
-      render('save_search') if render_save_this_search?
-    end
-
-    def render_save_this_search?
-      (current_exhibit and can?( :curate, current_exhibit)) &&
-      (params[:controller] != "spotlight_catalog_controller" && params[:action] != "admin")
-    end
-
     def select_deselect_button
       button_tag(
         t(:".deselect_all"),

--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -126,6 +126,11 @@ module Spotlight
       end
     end
 
+    def render_save_this_search?
+      (current_exhibit and can?( :curate, current_exhibit)) &&
+      !(params[:controller] == "spotlight/catalog" && params[:action] == "admin")
+    end
+
     private
 
     def main_app_url_helper?(method)

--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -31,7 +31,7 @@ module Spotlight
       return nil if document.nil?
 
       if current_exhibit
-        spotlight.exhibit_catalog_path(current_exhibit, document)
+        [spotlight, current_exhibit, document]
       else
         document
       end

--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -27,4 +27,18 @@ module Spotlight::MainAppHelpers
     field.enabled && field.send((:show if controller.is_a? Blacklight::Catalog and ["edit", "show"].include?(action_name)) || document_index_view_type)
   end
 
+  def link_back_to_catalog(opts={:label=>nil})
+    opts[:route_set] ||= spotlight if current_exhibit
+    super
+  end
+
+  def render_save_search
+    render('save_search') if render_save_this_search?
+  end
+
+  def render_save_this_search?
+    (current_exhibit and can?( :curate, current_exhibit)) &&
+    (params[:controller] != "spotlight_catalog_controller" && params[:action] != "admin")
+  end
+
 end

--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -28,17 +28,9 @@ module Spotlight::MainAppHelpers
   end
 
   def link_back_to_catalog(opts={:label=>nil})
-    opts[:route_set] ||= spotlight if current_exhibit
+    if (current_search_session.try(:query_params) || {}).fetch(:controller, "").starts_with? "spotlight"
+      opts[:route_set] ||= spotlight
+    end
     super
   end
-
-  def render_save_search
-    render('save_search') if render_save_this_search?
-  end
-
-  def render_save_this_search?
-    (current_exhibit and can?( :curate, current_exhibit)) &&
-    (params[:controller] != "spotlight_catalog_controller" && params[:action] != "admin")
-  end
-
 end

--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -15,7 +15,11 @@ module Spotlight::MainAppHelpers
     current_exhibit && current_exhibit.contact_emails.confirmed.any?
   end
   
-  def enabled_in_spotlight_view_type_configuration? config
+  def enabled_in_spotlight_view_type_configuration? config, *args
+    if config.respond_to? :upstream_if and !config.upstream_if.nil?
+      return false unless evaluate_configuration_conditional(config.upstream_if, config, *args)
+    end
+
     return true unless current_exhibit
 
     return true if controller.is_a? Spotlight::PagesController
@@ -24,7 +28,13 @@ module Spotlight::MainAppHelpers
   end
   
   def field_enabled? field, *args
-    field.enabled && field.send((:show if controller.is_a? Blacklight::Catalog and ["edit", "show"].include?(action_name)) || document_index_view_type)
+    return false unless field.enabled
+
+    if field.respond_to? :upstream_if and !field.upstream_if.nil?
+      return false unless evaluate_configuration_conditional(field.upstream_if, field, *args)
+    end
+
+    return field.send((:show if controller.is_a? Blacklight::Catalog and ["edit", "show"].include?(action_name)) || document_index_view_type)
   end
 
   def link_back_to_catalog(opts={:label=>nil})

--- a/app/models/concerns/spotlight/solr_document/active_model_concern.rb
+++ b/app/models/concerns/spotlight/solr_document/active_model_concern.rb
@@ -9,10 +9,6 @@ module Spotlight::SolrDocument::ActiveModelConcern
   
   module ClassMethods
 
-    def primary_key
-      :id
-    end
-    
     # needed for Rails 4.1 + act_as_taggable
     def dangerous_attribute_method? *args
       false

--- a/app/models/concerns/spotlight/solr_document/atomic_updates.rb
+++ b/app/models/concerns/spotlight/solr_document/atomic_updates.rb
@@ -12,7 +12,7 @@ module Spotlight::SolrDocument::AtomicUpdates
 
     data.map do |doc|
       Hash[doc.map do |k,v|
-        val = if k.to_sym == unique_key_field.to_sym
+        val = if k.to_sym == self.class.unique_key.to_sym
           v
         else
           { set: v }
@@ -21,13 +21,5 @@ module Spotlight::SolrDocument::AtomicUpdates
         [k,val]
       end]
     end.reject { |x| x.length <= 1 }
-  end
-
-  def unique_key_field
-    if respond_to?(:blacklight_config)
-      blacklight_config.solr_document_model.unique_key
-    else
-      'id'
-    end
   end
 end

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -64,6 +64,8 @@ module Spotlight
           config.navbar.partials[:search_history].if = false
         end
 
+        config.add_results_collection_tool 'save_search', if: :render_save_this_search?
+
         config.default_autocomplete_solr_params[:fl] ||= "#{config.solr_document_model.unique_key} #{config.view_config(:show).title_field} #{config.view_config(:show).thumbnail_field}"
 
         config.default_solr_params = config.default_solr_params.merge(default_solr_params)

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -86,7 +86,7 @@ module Spotlight
           else
             set_index_field_defaults(v)
           end
-          
+          v.upstream_if = v.if unless v.if.nil?
           v.if = :field_enabled?
 
           v.normalize! config
@@ -99,7 +99,8 @@ module Spotlight
           config.sort_fields = Hash[config.sort_fields.sort_by { |k,v| field_weight(sort_fields, k) }]
 
           config.sort_fields.each do |k, v|
-            v.if = ((sort_fields[k] || {})[:enabled] == true)
+            v.upstream_if = v.if unless v.if.nil?
+            v.if = :field_enabled?
             next if sort_fields[k].blank?
 
             v.merge! sort_fields[k].symbolize_keys
@@ -115,7 +116,8 @@ module Spotlight
             next if facet_fields[k].blank?
 
             v.merge! facet_fields[k].symbolize_keys
-            v.if = v.enabled
+            v.upstream_if = v.if unless v.if.nil?
+            v.if = :field_enabled?
             v.normalize! config
             v.validate!
           end
@@ -129,8 +131,9 @@ module Spotlight
         end
 
         config.view.each do |k,v|
-          config.view[k].key = k
-          config.view[k].if = :enabled_in_spotlight_view_type_configuration?
+          v.key = k
+          v.upstream_if = v.if unless v.if.nil?
+          v.if = :enabled_in_spotlight_view_type_configuration?
         end unless document_index_view_types.blank?
 
         config

--- a/app/views/catalog/_save_search.html.erb
+++ b/app/views/catalog/_save_search.html.erb
@@ -1,4 +1,4 @@
-<%= button_tag t(:'spotlight.saved_search.label'), class: 'btn btn-default',  data: {toggle:"modal", target:"#save-modal"} %>
+<%= button_tag t(:'spotlight.saved_search.label'), id: "save-this-search", class: 'btn btn-default',  data: {toggle:"modal", target:"#save-modal"} %>
 <div class="modal fade" id="save-modal" tabindex="-1" role="dialog" aria-labelledby="save-modal-label" aria-hidden="true">
   <div class="modal-dialog">
   <%= bootstrap_form_for [spotlight, current_exhibit, Spotlight::Search.new] do |f| %>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,9 +1,0 @@
-<div id="sortAndPerPage" class="clearfix">
-  <%= render :partial => "paginate_compact", :object => @response %>
-  <div class="search-widgets pull-right">
-    <%= render_save_search %>
-    <%= render :partial => 'sort_widget' %>
-    <%= render :partial => 'per_page_widget' %>
-    <%= render :partial => 'view_type_group' %>
-  </div>
-</div>

--- a/app/views/spotlight/catalog/_sort_and_per_page.html.erb
+++ b/app/views/spotlight/catalog/_sort_and_per_page.html.erb
@@ -1,9 +1,0 @@
-<div id="sortAndPerPage" class="clearfix">
-  <%= render :partial => "paginate_compact", :object => @response %>
-  <div class="search-widgets pull-right">
-    <%= render_save_search %>
-    <%= render :partial => 'sort_widget' %>
-    <%= render :partial => 'per_page_widget' %>
-    <%= render :partial => 'view_type_group' %>
-  </div>
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Spotlight::Engine.routes.draw do
       delete 'visiblity', to: "catalog#make_private"
     end
 
+    get "catalog/:id", to: "catalog#show", as: "solr_document"
+
     resources :solr_document, only: [:edit], to: 'catalog#edit'
 
     resources :custom_fields

--- a/lib/spotlight/catalog/access_controls_enforcement.rb
+++ b/lib/spotlight/catalog/access_controls_enforcement.rb
@@ -2,7 +2,7 @@ module Spotlight::Catalog::AccessControlsEnforcement
   extend ActiveSupport::Concern
 
   included do
-    self.solr_search_params_logic << :apply_permissive_visibility_filter
+    self.solr_search_params_logic += [:apply_permissive_visibility_filter]
   end
 
   protected

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -190,8 +190,9 @@ describe Spotlight::CatalogController, :type => :controller do
     end
     describe "PATCH update" do
       it "should be successful" do
-        patch :update, exhibit_id: exhibit, id: 'dq287tq6352', solr_document: {tag_list: 'one, two'}
-        expect(response).to be_redirect
+        expect {
+          patch :update, exhibit_id: exhibit, id: 'dq287tq6352', solr_document: {exhibit_tag_list: 'one, two'}
+        }.to change { exhibit.owned_taggings.count }.by(2)
       end
     end
 

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -1,14 +1,13 @@
 require "spec_helper"
 
 describe "Catalog", :type => :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
-  let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
-  before { login_as curator }
-
 
   describe "admin" do
-    
+    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
+
     before do
+      login_as curator
       d = SolrDocument.new(id: 'dq287tq6352')
       d.make_private! exhibit
       d.reindex
@@ -25,6 +24,12 @@ describe "Catalog", :type => :feature do
     it "should have a 'Item Visiblity' facet" do
       visit spotlight.exhibit_catalog_index_path(exhibit)
       expect(page).to have_selector '.panel-title', text: "Item Visibility"
+    end
+  end
+  describe 'Non-spotlight #show' do
+    it 'should be able to render without exhibit context' do
+      visit catalog_path('dq287tq6352')
+      expect(page).to have_css "h1", text: "L'AMERIQUE"
     end
   end
 end

--- a/spec/helpers/spotlight/application_helper_spec.rb
+++ b/spec/helpers/spotlight/application_helper_spec.rb
@@ -56,37 +56,6 @@ describe Spotlight::ApplicationHelper, :type => :helper do
       end
     end
   end
-  describe "save_search rendering" do
-    let(:current_exhibit) { FactoryGirl.create(:exhibit) }
-    before { allow(helper).to receive_messages(current_exhibit: current_exhibit) }
-    describe "render_save_this_search?" do
-      it "should return false if we are on the items admin screen" do
-        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(true)
-        allow(helper).to receive(:params).and_return({controller: "spotlight_catalog_controller", action: "admin"})
-        expect(helper.render_save_this_search?).to be_falsey
-      end
-      it "should return true if we are on the items admin screen" do
-        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(true)
-        allow(helper).to receive(:params).and_return({controller: "catalog_controller", action: "index"})
-        expect(helper.render_save_this_search?).to be_truthy
-      end
-      it "should return false if a user cannot curate the object" do
-        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(false)
-        expect(helper.render_save_this_search?).to be_falsey
-      end
-    end
-    describe "render_save_search" do
-      it "should do render the save_search partial if render_save_this_search? return true" do
-        allow(helper).to receive(:"render_save_this_search?").and_return true
-        allow(helper).to receive(:render).with('save_search').and_return "saved-search-partial"
-        expect(helper.render_save_search).to eq "saved-search-partial"
-      end
-      it "should do nothing if render_save_this_search? return false" do
-        allow(helper).to receive(:"render_save_this_search?").and_return false
-        expect(helper.render_save_search).to be_blank
-      end
-    end
-  end
   describe 'render_document_class' do
     let(:current_exhibit) { FactoryGirl.create(:exhibit) }
     let(:document) { SolrDocument.new(some_field: "Some data") }

--- a/spec/helpers/spotlight/application_helper_spec.rb
+++ b/spec/helpers/spotlight/application_helper_spec.rb
@@ -109,4 +109,25 @@ describe Spotlight::ApplicationHelper, :type => :helper do
       expect(helper.carrierwave_url(upload)).to eq "http://some.host/x/y/z"
     end
   end
+  
+  describe "save_search rendering" do
+    let(:current_exhibit) { FactoryGirl.create(:exhibit) }
+    before { allow(helper).to receive_messages(current_exhibit: current_exhibit) }
+    describe "render_save_this_search?" do
+      it "should return false if we are on the items admin screen" do
+        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(true)
+        allow(helper).to receive(:params).and_return({controller: "spotlight/catalog", action: "admin"})
+        expect(helper.render_save_this_search?).to be_falsey
+      end
+      it "should return true if we are not on the items admin screen" do
+        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(true)
+        allow(helper).to receive(:params).and_return({controller: "spotlight/catalog", action: "index"})
+        expect(helper.render_save_this_search?).to be_truthy
+      end
+      it "should return false if a user cannot curate the object" do
+        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(false)
+        expect(helper.render_save_this_search?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/helpers/spotlight/application_helper_spec.rb
+++ b/spec/helpers/spotlight/application_helper_spec.rb
@@ -50,7 +50,6 @@ describe Spotlight::ApplicationHelper, :type => :helper do
         allow(helper).to receive_messages(blacklight_config: config)
       end
       it "should return a blacklight configuration object that has reduced the views to those that are configured in the block" do
-        expect(config.view.keys).to eq [:list, :gallery, :slideshow]
         new_config = helper.blacklight_view_config_for_search_block(sir_trevor_block)
         expect(new_config.keys).to eq [:list, :gallery]
       end

--- a/spec/helpers/spotlight/main_app_helpers_spec.rb
+++ b/spec/helpers/spotlight/main_app_helpers_spec.rb
@@ -49,4 +49,37 @@ describe Spotlight::MainAppHelpers, :type => :helper do
       expect(helper.field_enabled?(field)).to eq :value
     end
   end
+
+  describe "save_search rendering" do
+    let(:current_exhibit) { FactoryGirl.create(:exhibit) }
+    before { allow(helper).to receive_messages(current_exhibit: current_exhibit) }
+    describe "render_save_this_search?" do
+      it "should return false if we are on the items admin screen" do
+        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(true)
+        allow(helper).to receive(:params).and_return({controller: "spotlight_catalog_controller", action: "admin"})
+        expect(helper.render_save_this_search?).to be_falsey
+      end
+      it "should return true if we are on the items admin screen" do
+        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(true)
+        allow(helper).to receive(:params).and_return({controller: "catalog_controller", action: "index"})
+        expect(helper.render_save_this_search?).to be_truthy
+      end
+      it "should return false if a user cannot curate the object" do
+        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(false)
+        expect(helper.render_save_this_search?).to be_falsey
+      end
+    end
+    describe "render_save_search" do
+      it "should do render the save_search partial if render_save_this_search? return true" do
+        allow(helper).to receive(:"render_save_this_search?").and_return true
+        allow(helper).to receive(:render).with('save_search').and_return "saved-search-partial"
+        expect(helper.render_save_search).to eq "saved-search-partial"
+      end
+      it "should do nothing if render_save_this_search? return false" do
+        allow(helper).to receive(:"render_save_this_search?").and_return false
+        expect(helper.render_save_search).to be_blank
+      end
+    end
+  end
+
 end

--- a/spec/helpers/spotlight/main_app_helpers_spec.rb
+++ b/spec/helpers/spotlight/main_app_helpers_spec.rb
@@ -50,36 +50,4 @@ describe Spotlight::MainAppHelpers, :type => :helper do
     end
   end
 
-  describe "save_search rendering" do
-    let(:current_exhibit) { FactoryGirl.create(:exhibit) }
-    before { allow(helper).to receive_messages(current_exhibit: current_exhibit) }
-    describe "render_save_this_search?" do
-      it "should return false if we are on the items admin screen" do
-        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(true)
-        allow(helper).to receive(:params).and_return({controller: "spotlight_catalog_controller", action: "admin"})
-        expect(helper.render_save_this_search?).to be_falsey
-      end
-      it "should return true if we are on the items admin screen" do
-        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(true)
-        allow(helper).to receive(:params).and_return({controller: "catalog_controller", action: "index"})
-        expect(helper.render_save_this_search?).to be_truthy
-      end
-      it "should return false if a user cannot curate the object" do
-        allow(helper).to receive(:"can?").with(:curate, current_exhibit).and_return(false)
-        expect(helper.render_save_this_search?).to be_falsey
-      end
-    end
-    describe "render_save_search" do
-      it "should do render the save_search partial if render_save_this_search? return true" do
-        allow(helper).to receive(:"render_save_this_search?").and_return true
-        allow(helper).to receive(:render).with('save_search').and_return "saved-search-partial"
-        expect(helper.render_save_search).to eq "saved-search-partial"
-      end
-      it "should do nothing if render_save_this_search? return false" do
-        allow(helper).to receive(:"render_save_this_search?").and_return false
-        expect(helper.render_save_search).to be_blank
-      end
-    end
-  end
-
 end

--- a/spec/helpers/spotlight/main_app_helpers_spec.rb
+++ b/spec/helpers/spotlight/main_app_helpers_spec.rb
@@ -48,6 +48,35 @@ describe Spotlight::MainAppHelpers, :type => :helper do
       allow(helper).to receive(:action_name).and_return("edit")
       expect(helper.field_enabled?(field)).to eq :value
     end
+    it "should return the value of the original if condition" do
+      allow(field).to receive(:upstream_if).and_return false
+      expect(helper.field_enabled?(field)).to eq false 
+    end
+  end
+
+  describe "#enabled_in_spotlight_view_type_configuration?" do
+    let(:controller) { OpenStruct.new }
+    let(:view) { OpenStruct.new }
+    before do
+      controller.extend(Blacklight::Catalog)
+      allow(helper).to receive(:controller).and_return(controller)
+    end
+
+    it "should respect the original if condition" do
+      view.upstream_if = false
+      expect(helper.enabled_in_spotlight_view_type_configuration?(view)).to eq false
+    end
+
+    it "should be true if there is no exhibit context" do
+      allow(helper).to receive(:current_exhibit).and_return(nil)
+      expect(helper.enabled_in_spotlight_view_type_configuration?(view)).to eq true
+    end
+    
+    it "should be true if we're in a page context" do
+      allow(helper).to receive(:current_exhibit).and_return(nil)
+      allow(controller).to receive(:is_a?).with(Spotlight::PagesController).and_return(true)
+      expect(helper.enabled_in_spotlight_view_type_configuration?(view)).to eq true
+    end
   end
 
 end

--- a/spec/models/spotlight/appearance_spec.rb
+++ b/spec/models/spotlight/appearance_spec.rb
@@ -41,4 +41,15 @@ describe Spotlight::Appearance, :type => :model do
       end
     end
   end
+
+  describe "#view_type_options" do
+    subject { Spotlight::Appearance.new(config).view_type_options }
+    it "should include the available view types" do
+      expect(subject).to include :list, :gallery, :slideshow
+    end
+
+    it "should not include rss or atom" do
+      expect(subject).not_to include :rss, :atom
+    end
+  end
 end

--- a/spec/models/spotlight/blacklight_configuration_spec.rb
+++ b/spec/models/spotlight/blacklight_configuration_spec.rb
@@ -112,7 +112,7 @@ describe Spotlight::BlacklightConfiguration, :type => :model do
     context "custom fields" do
       it "should include any custom fields" do
         subject.index_fields['a'] = { enabled: true, list: true }
-        allow(subject).to receive_messages(custom_index_fields: { 'a' => double(:if= => true, merge!: true, validate!: true, normalize!: true) })
+        allow(subject).to receive_messages(custom_index_fields: { 'a' => double(if: nil, :if= => true, merge!: true, validate!: true, normalize!: true) })
         expect(subject.blacklight_config.index_fields).to include('a')
       end
 
@@ -175,7 +175,7 @@ describe Spotlight::BlacklightConfiguration, :type => :model do
     it "should include any custom fields" do
       subject.index_fields['a'] = { enabled: true, show: true }
 
-      allow(subject).to receive_messages(custom_index_fields: { 'a' => double(:if= => true, merge!: true, validate!: true, normalize!: true) })
+      allow(subject).to receive_messages(custom_index_fields: { 'a' => double(if: nil, :if= => true, merge!: true, validate!: true, normalize!: true) })
 
       expect(subject.blacklight_config.show_fields).to include('a')
     end
@@ -248,8 +248,8 @@ describe Spotlight::BlacklightConfiguration, :type => :model do
       blacklight_config.add_sort_field 'b'
       blacklight_config.add_sort_field 'c'
 
-      expect(subject.blacklight_config.sort_fields.select { |k,v| v.if == true}).to include('a', 'c')
-      expect(subject.blacklight_config.sort_fields.select { |k,v| v.if == false}).to include('b')
+      expect(subject.blacklight_config.sort_fields.select { |k,v| v.enabled == true}).to include('a', 'c')
+      expect(subject.blacklight_config.sort_fields.select { |k,v| v.enabled == true}).not_to include('b', 'd')
     end
   end
 


### PR DESCRIPTION
I think this fixes #896 

Once I fixed the `#apply_permissive_visibility_filter` issue there were some helpers that were throwing errors.

Not sure if I'm doing the right thing with the `#link_back_to_catalog` override or not, so let me know if you have other ideas.