### PR TITLE
Use explicit named routes when linking to the singular HomePage resource

### DIFF
--- a/app/views/spotlight/dashboards/_page.html.erb
+++ b/app/views/spotlight/dashboards/_page.html.erb
@@ -2,8 +2,13 @@
   <td>
     <h4 class="panel-title"><%= page.title %></h4>
     <div class="page-links">
-      <%= exhibit_view_link page, :class => 'btn btn-link' %> &middot;
-      <%= exhibit_edit_link page, :class => 'btn btn-link' %>
+      <% if page.is_a?(Spotlight::HomePage) %>
+          <%= link_to action_default_value(page, :view), current_exhibit, :class => 'btn btn-link' %> &middot;
+          <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), :class => 'btn btn-link' %>
+      <% else %>
+        <%= exhibit_view_link page, :class => 'btn btn-link' %> &middot;
+        <%= exhibit_edit_link page, :class => 'btn btn-link' %>
+      <% end %>
     </div>
   </td>
   <td><%= page.last_edited_by.to_s if page.last_edited_by %></td>

--- a/app/views/spotlight/home_pages/_edit_page_link.html.erb
+++ b/app/views/spotlight/home_pages/_edit_page_link.html.erb
@@ -1,0 +1,1 @@
+<%= exhibit_edit_link @page, edit_exhibit_home_page_path(@page.exhibit), class: 'edit-button pull-right btn btn-primary' %>

--- a/app/views/spotlight/pages/_edit_page_link.html.erb
+++ b/app/views/spotlight/pages/_edit_page_link.html.erb
@@ -1,0 +1,1 @@
+<%= exhibit_edit_link @page, class: 'edit-button pull-right btn btn-primary' %>

--- a/app/views/spotlight/pages/show.html.erb
+++ b/app/views/spotlight/pages/show.html.erb
@@ -5,12 +5,12 @@
 <%= cache_unless current_user, @page do %>
 <div class="<%= 'col-md-9' if @page.display_sidebar? %>">
   <div class="clearfix">
-  <%= exhibit_edit_link @page, class: 'edit-button pull-right btn btn-primary' if can? :edit, @page %>
-  <% if @page.should_display_title? %>
-    <h1 class="page-title">
-      <%= @page.title %>
-    </h1>
-  <% end %>
+    <%= render 'edit_page_link' if can? :edit, @page %>
+    <% if @page.should_display_title? %>
+      <h1 class="page-title">
+        <%= @page.title %>
+      </h1>
+    <% end %>
   </div>
   <div>
     <%= render @page.content if @page.has_content? %>


### PR DESCRIPTION
This PR makes the edit and view links for home pages `/:exhibit_id/home/edit` and `/:exhibit_id` respectively.

We need to have separate logic for home pages because they are a singular resource as opposed to the about and feature pages (see rails/rails#1769).