### PR TITLE
Add Featured Browse Categories Widget

### DIFF
--- a/app/assets/javascripts/spotlight/blocks/featured_browse_categories_block.js
+++ b/app/assets/javascripts/spotlight/blocks/featured_browse_categories_block.js
@@ -1,0 +1,170 @@
+/*
+  Block to get allow a user to choose browse
+  categories to feature on various pages.
+*/
+
+SirTrevor.Blocks.FeaturedBrowseCategories =  (function(){
+
+  return Spotlight.Block.extend({
+
+  searches_key: "featured-browse-categories",
+
+  blockGroup: 'Exhibit item widgets',
+
+  description: "This block visually highlights up to five browse categories, which are linked to the browse category results page.",
+
+  maxCategoriesAllowed: 5,
+
+  template: [
+    '<div class="featured-browse-categories-block-admin clearFix">',
+      '<div class="widget-header">',
+        '<%= description %>',
+      '</div>',
+      '<div class="col-sm-12">',
+        '<label for="<%= formId(searches_key) %>">Browse categories</label>',
+        '<div id="<%= formId(searches_key) %>" data-featured-browse-categories="true">',
+        '</div>',
+      '</div>',
+    '</div>'
+  ].join("\n"),
+
+  onBlockRender: function(data){
+    Spotlight.Block.prototype.onBlockRender.apply();
+    this.loadSearchOptions();
+  },
+
+  afterLoadData: function(data){
+    var selected = [];
+    $.each(data, function(k, v){
+      if(k != "display-item-counts" && !k.match(/^weight-/) && v) {
+        selected.push(k);
+      }
+    });
+    if(data["display-item-counts"]){
+      selected.push("display-item-counts");
+    }
+
+    this.$('#' + this.formId(this.searches_key)).data('sort-after-ajax', this.orderData(data));
+    this.$('#' + this.formId(this.searches_key)).data('select-after-ajax', selected);
+  },
+
+  orderData: function(data){
+    var sortData = [];
+    var sortOrder = [];
+    $.each(data, function(k, v){
+      if(k.match(/^weight-\S+/)){
+        sortData.push({
+          slug: k.replace('weight-', ''),
+          sort: v
+        });
+      }
+    });
+    $.each(sortData.sort(function(a,b) {return a['sort'] > b['sort']}), function(){
+      sortOrder.push($(this)[0]['slug']);
+    });
+    return sortOrder;
+  },
+
+  categoryTemplate: function(searches){
+    var block = this;
+    var output = '';
+    output += '<div class="col-sm-7 form-group form-inline panel-group dd nestable-featured-browse" data-behavior="nestable" data-max-depth="1">';
+      output += '<ol class="dd-list">';
+      $.each(block.sortedSearches(searches), function(i, search){
+        output += block.searchTemplate(i, search);
+      });
+      output += '</ol>';
+    output += '</div>';
+    return output;
+  },
+
+  sortedSearches: function(searches){
+    var sortOrder = this.$('#' + this.formId(this.searches_key)).data('sort-after-ajax') || [];
+    return searches.sort(function(a,b){
+      return sortOrder.indexOf(String(a.slug)) > sortOrder.indexOf(String(b.slug));
+    });
+  },
+
+  searchTemplate: function(i, search){
+    return [
+      '<li class="dd-item dd3-item" data-id="' + search.slug + '">',
+        '<div class="dd3-content panel panel-default">',
+          '<div class="dd-handle dd3-handle">Drag</div>',
+          '<div class="panel-heading item-grid">',
+            '<div class="checkbox">',
+              '<input data-nestable-limit-categories="true" id="' + this.formId(search.slug) + '" name="' +  search.slug + '" type="checkbox" value="true" /> ',
+            '</div>',
+            '<div class="pic thumbnail">',
+              '<img  src="' + search.featured_image + '" />',
+            '</div>',
+            '<div class="main">',
+              '<div class="title panel-title" data-panel-title="true">' + search.title + '</div>',
+              search.count + ' items',
+            '</div>',
+            '<input type="hidden" data-property="weight" value="' + i + '" name="weight-' + search.slug + '" />',
+          '</div>',
+        '</div>',
+      '</li>'
+    ].join("\n")
+  },
+
+  showCountsTemplate: function(){
+    return [
+      '<div class="col-sm-3 col-sm-offset-1">',
+        '<label>',
+          '<input type="checkbox" name="display-item-counts" value="true" checked />',
+          "Include item counts?",
+        '</label>',
+      '</div>'
+    ].join("\n")
+  },
+
+  applySelectedFeaturedCategories: function(){
+    var block = this;
+    var container = block.$('#' + block.formId(block.searches_key));
+    var selected = container.data('select-after-ajax') || [];
+    $.each(selected, function(i, name){
+      block.$('input[type="checkbox"][name="' + name + '"]', container).prop('checked', true)
+    });
+
+    if(selected.length > 0 && selected.indexOf("display-item-counts") < 0) {
+      block.$('input[type="checkbox"][name="display-item-counts"]', container).prop('checked', false)
+    }
+  },
+
+  applyMaxCategoryLimit: function(){
+    var block = this;
+    var selector = "[data-nestable-limit-categories='true']";
+    this.$(selector).click(function(){
+      if(block.$(selector + ":checked").length > block.maxCategoriesAllowed){
+        return false;
+      }
+    });
+  },
+
+  loadSearchOptions: function(){
+    var block = this;
+    var searches_url = $('form[data-searches-endpoint]').data('searches-endpoint');
+    var browseCategoryElement = this.$('#' + this.formId(this.searches_key));
+    $.ajax({
+      accepts: "json",
+      url: searches_url
+    }).success(function(data){
+      browseCategoryElement.append(block.categoryTemplate(data));
+      browseCategoryElement.append(block.showCountsTemplate());
+      block.applySelectedFeaturedCategories();
+      block.applyMaxCategoryLimit();
+      SpotlightNestable.init();
+      // re-serialze the form so the form observer
+      // knows about the new drop dwon options.
+      serializeFormStatus($('form[data-searches-endpoint]'));
+    });
+  },
+
+  type: "featured_browse_categories",
+
+  title: function() { return "Featured Browse Categories"; },
+
+  icon_name: 'featured_browse_categories',
+});
+})();

--- a/app/assets/stylesheets/spotlight/_featured_browse_categories_block.scss
+++ b/app/assets/stylesheets/spotlight/_featured_browse_categories_block.scss
@@ -1,0 +1,90 @@
+$featured-browse-category-border-color: $legend-border-color;
+$featured-browse-category-caption-color: $gray-lighter;
+$smallest-featured-browse-category-width: 220px;
+$smallest-featured-browse-category-height: $smallest-featured-browse-category-width;
+$largest-featured-browse-category-height: 255px;
+$no-sidebar-medium-image-width: 300px;
+$no-sidebar-large-image-width: 360px;
+$with-sidebar-medium-image-width: 340px;
+$with-sidebar-large-image-width: $no-sidebar-large-image-width;
+
+.browse-category {
+  background-size: cover;
+  background-position: center;
+  border: 2px solid $featured-browse-category-border-color;
+  border-radius: $border-radius-large;
+  position: relative;
+  float: left;
+  background-repeat: no-repeat;
+  .category-caption {
+    color: $featured-browse-category-caption-color;
+    position: absolute;
+    bottom: $line-height-computed;
+    text-align: center;
+    text-shadow: 0 1px 0 #000000;
+    width: 100%;
+  }
+  .category-title {
+    font-size: $font-size-large;
+    line-height: 1.2;
+    margin: 0;
+    padding: $table-condensed-cell-padding;
+  }
+  .item-count {
+    font-size: $font-size-base;
+    text-transform: uppercase;
+  }
+}
+
+[data-sidebar="false"] {
+  &.categories-1, &.categories-2, &.categories-3 {
+    .browse-category {
+      height: $largest-featured-browse-category-height;
+      @media (max-width: $screen-md-max) {
+        width: $no-sidebar-medium-image-width;
+      }
+      @media (min-width: $screen-lg-min) {
+        width: $no-sidebar-large-image-width;
+      }
+    }
+  }
+  &.categories-4, &.categories-5 {
+    .browse-category {
+      width: $smallest-featured-browse-category-width;
+      height: $smallest-featured-browse-category-height;
+    }
+    .category-4 {
+      @extend .hidden-sm;
+    }
+    .category-5 {
+      @extend .hidden-md;
+      @extend .hidden-sm;
+    }
+  }
+}
+
+[data-sidebar="true"] {
+  &.categories-1, &.categories-2 {
+    .browse-category {
+      height: $largest-featured-browse-category-height;
+      @media (max-width: $screen-md-max) {
+        width: $with-sidebar-medium-image-width;
+      }
+      @media (min-width: $screen-lg-min) {
+        width: $with-sidebar-large-image-width;
+      }
+    }
+  }
+  &.categories-3, &.categories-4, &.categories-5 {
+   .browse-category {
+      width: $smallest-featured-browse-category-width;
+      height: $smallest-featured-browse-category-height;
+    }
+  }
+  .category-3 {
+    @extend .hidden-sm;
+  }
+  .category-4, .category-5 {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/spotlight/_spotlight.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.scss
@@ -13,6 +13,7 @@
 @import "spotlight/curation";
 @import "spotlight/exhibit_admin";
 @import "spotlight/edit_in_place";
+@import "spotlight/featured_browse_categories_block";
 @import "spotlight/item_text_block";
 @import "spotlight/multi_image_selector";
 @import "spotlight/multi_up_item_grid";

--- a/app/models/sir_trevor_rails/blocks/featured_browse_categories_block.rb
+++ b/app/models/sir_trevor_rails/blocks/featured_browse_categories_block.rb
@@ -1,0 +1,65 @@
+module SirTrevorRails::Blocks
+  class FeaturedBrowseCategoriesBlock < SirTrevorRails::Block
+    attr_reader :solr_helper
+
+    def with_solr_helper solr_helper
+      @solr_helper = solr_helper
+    end
+
+    def display_item_counts?
+      as_json[:data][:"display-item-counts"]
+    end
+
+    def block_objects
+      @block_objects ||= sorted_browse_categories.map do |category|
+        OpenStruct.new(
+          browse_category: category,
+          count: item_counts_for_category(category)
+        )
+      end
+    end
+
+    private
+
+    def sorted_browse_categories
+      browse_categories.sort do |a,b|
+        order_data.index(a.slug) <=> order_data.index(b.slug)
+      end
+    end
+
+    def order_data
+      data.select do |k,_|
+        k =~ /^weight-\S+/
+      end.compact.sort_by{|_,v| v}.map do |k,_|
+        k[/^weight-(\S+)/]; $1
+      end
+    end
+
+    def browse_categories
+      @browse_categories ||= parent.exhibit.searches.select do |search|
+        category_slugs.include?(search.slug)
+      end
+    end
+
+    def item_counts_for_category(category)
+      solr_helper.get_search_results(category.query_params).first["response"]["numFound"]
+    end
+
+    def data
+      as_json[:data].stringify_keys
+    end
+
+    def slug_data
+      data.except(:"display-item-counts").except do |k,_|
+        k =~ /^weight/
+      end
+    end
+
+    def category_slugs
+      @category_ids ||= slug_data.map do |slug, enabled|
+        slug if enabled
+      end.compact
+    end
+
+  end
+end

--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -50,6 +50,10 @@ class Spotlight::Search < ActiveRecord::Base
     end
   end
 
+  def as_json(*args)
+    super.merge(featured_image: featured_image, count: count)
+  end
+
   def default_featured_item_id
     images.first.first if images.present?
   end

--- a/app/views/spotlight/sir_trevor/blocks/_featured_browse_categories_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_featured_browse_categories_block.html.erb
@@ -1,0 +1,19 @@
+<% featured_browse_categories_block.with_solr_helper(self) %>
+<div class="spotlight-flexbox browse-categories categories-<%= featured_browse_categories_block.block_objects.length %>" data-sidebar='<%= @page.display_sidebar? %>'>
+  <% featured_browse_categories_block.block_objects.each_with_index do |block_object, index| %>
+    <div class="box category-<%= (index + 1) %>">
+      <a href="<%= spotlight.exhibit_browse_path(current_exhibit, block_object.browse_category) %>">
+        <div class="browse-category" style='background-image: linear-gradient(rgba(0, 0, 0, 0.0), rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.5)), url("<%= block_object.browse_category.featured_image %>")'>
+          <div class="category-caption">
+            <p class="category-title">
+              <%= block_object.browse_category.title %>
+            </p>
+            <% if featured_browse_categories_block.display_item_counts? %>
+              <span class="item-count"><%= pluralize(block_object.count, 'item') %></span>
+            <% end %>
+          </div>
+        </div>
+      </a>
+    </div>
+  <% end %>
+</div>

--- a/spec/features/javascript/featured_browse_categories_block_spec.rb
+++ b/spec/features/javascript/featured_browse_categories_block_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe "Featured Browse Categories Block", type: :feature, js: true do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let!(:search1) { FactoryGirl.create(:search, exhibit: exhibit, title: "Title1") }
+  let!(:search2) { FactoryGirl.create(:search, exhibit: exhibit, title: "Title2") }
+  let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
+  let(:all_items_title) { "All Exhibit Items" }
+
+  before { login_as exhibit_curator }
+
+  it 'should save the selected exhibits' do
+    visit spotlight.exhibit_home_page_path(exhibit, exhibit.home_page)
+
+    click_link("Edit")
+
+    add_widget 'featured_browse_categories'
+
+    expect(find('[name="display-item-counts"]')).to be_checked
+
+    expect(page).to have_css('.panel-title', text: all_items_title)
+    expect(page).to have_css('.panel-title', text: search1.title)
+    expect(page).to have_css('.panel-title', text: search2.title)
+
+    check(search1.slug)
+
+    save_page
+
+    expect(page).to_not have_css('.category-title', text: all_items_title)
+    expect(page).to_not have_css('.category-title', text: search2.title)
+    expect(page).to have_css('.category-title', text: search1.title)
+    expect(page).to have_css('.item-count', text: /\d+ items/i)
+  end
+
+end


### PR DESCRIPTION
Closes #914 

Still working out some kinks w/ the tests.  Also, @ggeisler can you take a look at the 5 category w/ no-sidebar on different view-ports.  Under certain circumstances I see the categories overlapping.

TODO:
- [x] Use variables for height, width, colors, etc.
- [x] Pick and set a good fallback size for the browse categories (falling back on smallest square).
- [x] Store browse category slug instead of ID.
- [x] Make `Show item counts` enabled by default.

## Edit form
![edit](https://cloud.githubusercontent.com/assets/96776/6090395/4f345fb6-ae2c-11e4-9ddd-84b693490efa.png)

## With Sidebar
![sidebar-2](https://cloud.githubusercontent.com/assets/96776/6090396/4f3531fc-ae2c-11e4-8359-c051feba7160.png)

![sidebar-3](https://cloud.githubusercontent.com/assets/96776/6090398/4f38b5b6-ae2c-11e4-93df-69d359c005f3.png)


## Without Sidebar
![no-sidebar-2](https://cloud.githubusercontent.com/assets/96776/6090393/4f33e48c-ae2c-11e4-9fb7-c1975c94c51d.png)
![no-sidebar-3](https://cloud.githubusercontent.com/assets/96776/6090394/4f33c7a4-ae2c-11e4-9f18-cad327c6f8be.png)
![no-sidebar-4](https://cloud.githubusercontent.com/assets/96776/6090399/4f4af816-ae2c-11e4-8c2c-ef8172cfdf37.png)
![no-sidebar-5](https://cloud.githubusercontent.com/assets/96776/6090397/4f385f80-ae2c-11e4-8c25-f06480bdccce.png)
