### PR TITLE
Allow uploaded field configuration to support mapping to multiple solr fields

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -153,7 +153,7 @@ class Spotlight::CatalogController < ::CatalogController
 
   def uploaded_resource_params
     if @document.uploaded_resource?
-      return Spotlight::Resources::Upload.fields(current_exhibit).collect(&:solr_field)
+      return Spotlight::Resources::Upload.fields(current_exhibit).collect(&:field_name)
     end
     []
   end

--- a/app/controllers/spotlight/resources/upload_controller.rb
+++ b/app/controllers/spotlight/resources/upload_controller.rb
@@ -53,7 +53,7 @@ module Spotlight::Resources
     end
 
     def data_param_keys
-      Spotlight::Resources::Upload.fields(current_exhibit).collect(&:solr_field) + current_exhibit.custom_fields.collect(&:field)
+      Spotlight::Resources::Upload.fields(current_exhibit).collect(&:field_name) + current_exhibit.custom_fields.collect(&:field)
     end
 
   end

--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -131,6 +131,11 @@ module Spotlight
       !(params[:controller] == "spotlight/catalog" && params[:action] == "admin")
     end
 
+    def uploaded_field_label config
+      solr_field = Array(config.solr_field || config.field_name).first.to_s
+      config.label || blacklight_config.index_fields[solr_field].try(:label) || t(".#{solr_field}")
+    end
+
     private
 
     def main_app_url_helper?(method)

--- a/app/models/spotlight/resources/upload.rb
+++ b/app/models/spotlight/resources/upload.rb
@@ -3,7 +3,8 @@ module Spotlight
     mount_uploader :url, Spotlight::ItemUploader
 
     def self.fields(exhibit)
-      @fields ||= self.new(exhibit: exhibit).configured_fields
+      @fields ||= {}
+      @fields[exhibit] ||= self.new(exhibit: exhibit).configured_fields
     end
 
     def configured_fields
@@ -34,7 +35,7 @@ module Spotlight
 
     # this is in the upload class because it has exhibit context
     def configured_title_field
-      OpenStruct.new(solr_field: exhibit.blacklight_config.index.title_field)
+      OpenStruct.new(field_name: exhibit.blacklight_config.index.title_field)
     end
     
     def add_default_solr_fields solr_hash
@@ -57,9 +58,12 @@ module Spotlight
     end
 
     def add_configured_fields solr_hash
-      configured_fields.collect(&:solr_field).each do |solr_field|
-        if data[solr_field].present?
-          solr_hash[solr_field] = data[solr_field]
+      configured_fields.each do |field|
+        solr_fields = Array(field.solr_field || field.field_name)
+        if data[field.field_name].present?
+          solr_fields.each do |solr_field|
+            solr_hash[solr_field] = data[field.field_name]
+          end
         end
       end
     end

--- a/app/models/spotlight/resources/upload.rb
+++ b/app/models/spotlight/resources/upload.rb
@@ -35,7 +35,7 @@ module Spotlight
 
     # this is in the upload class because it has exhibit context
     def configured_title_field
-      OpenStruct.new(field_name: exhibit.blacklight_config.index.title_field)
+      Spotlight::Engine.config.upload_title_field || OpenStruct.new(field_name: exhibit.blacklight_config.index.title_field)
     end
     
     def add_default_solr_fields solr_hash

--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -16,7 +16,7 @@
       <% end %>
       <% if document.uploaded_resource? %>
         <% Spotlight::Resources::Upload.fields(current_exhibit).each do |config| %>
-          <%= d.send((config.form_field_type || :text_field), config.solr_field, value: document.first(config.solr_field), label: current_exhibit.blacklight_config.index_fields[config.solr_field.to_s].try(:label) || t(".#{config.solr_field}")) %>
+          <%= d.send((config.form_field_type || :text_field), config.field_name, value: document.first(config.solr_field), label: uploaded_field_label(config)) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/spotlight/resources/upload/_single_item_form.html.erb
+++ b/app/views/spotlight/resources/upload/_single_item_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.url_field :url, type: "file", help: t('.url-field.help', extensions: Spotlight::Engine.config.allowed_upload_extensions.join(' ')), label: "File" %>
   <%= f.fields_for :data do |d| %>
     <% Spotlight::Resources::Upload.fields(current_exhibit).each do |config| %>
-      <%= d.send((config.form_field_type || :text_field), config.solr_field, label: current_exhibit.blacklight_config.index_fields[config.solr_field.to_s].try(:label) || t(".#{config.solr_field}")) %>
+      <%= d.send((config.form_field_type || :text_field), config.field_name, label: uploaded_field_label(config)) %>
     <% end %>
     <% current_exhibit.custom_fields.each do |custom_field| %>
       <%= d.text_field custom_field.field, label: custom_field.label %>

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -60,9 +60,9 @@ module Spotlight
     Spotlight::Engine.config.uploaded_date_field = :spotlight_upload_date_tesim
 
     Spotlight::Engine.config.upload_fields = [
-      OpenStruct.new(solr_field: Spotlight::Engine.config.uploaded_description_field, form_field_type: :text_area),
-      OpenStruct.new(solr_field: Spotlight::Engine.config.uploaded_attribution_field),
-      OpenStruct.new(solr_field: Spotlight::Engine.config.uploaded_date_field)
+      OpenStruct.new(field_name: Spotlight::Engine.config.uploaded_description_field, form_field_type: :text_area),
+      OpenStruct.new(field_name: Spotlight::Engine.config.uploaded_attribution_field),
+      OpenStruct.new(field_name: Spotlight::Engine.config.uploaded_date_field)
     ]
 
     Blacklight::Engine.config.inject_blacklight_helpers = false

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -59,6 +59,9 @@ module Spotlight
     Spotlight::Engine.config.uploaded_attribution_field = :spotlight_upload_attribution_tesim
     Spotlight::Engine.config.uploaded_date_field = :spotlight_upload_date_tesim
 
+    # Defaults to the blacklight_config.index.title_field:
+    Spotlight::Engine.config.upload_title_field = nil # OpenStruct.new(...)
+
     Spotlight::Engine.config.upload_fields = [
       OpenStruct.new(field_name: Spotlight::Engine.config.uploaded_description_field, form_field_type: :text_area),
       OpenStruct.new(field_name: Spotlight::Engine.config.uploaded_attribution_field),

--- a/spec/features/upload_non_repository_item_spec.rb
+++ b/spec/features/upload_non_repository_item_spec.rb
@@ -11,6 +11,7 @@ describe "Uploading a non-repository item", :type => :feature do
       visit spotlight.new_exhibit_resources_upload_path(exhibit)
       expect(page).to have_css("h1", text: /Curation/)
       expect(page).to have_css "h1 small", text: "Add non-repository items"
+
       within("form#new_resources_upload") do
         expect(page).to have_css('#resources_upload_url[type="file"]')
         expect(page).to have_css('.help-block', text: 'Valid file types: jpg jpeg png')

--- a/spec/helpers/spotlight/application_helper_spec.rb
+++ b/spec/helpers/spotlight/application_helper_spec.rb
@@ -129,4 +129,28 @@ describe Spotlight::ApplicationHelper, :type => :helper do
       end
     end
   end
+
+  describe "#uploaded_field_label" do
+    let :field do
+      OpenStruct.new field_name: 'x'
+    end
+
+    let :blacklight_config do
+      Blacklight::Configuration.new
+    end
+
+    before do
+      allow(helper).to receive_messages(blacklight_config: blacklight_config)
+    end
+
+    it "should use the configuration-provided label" do
+      field.label = 'label x'
+      expect(helper.uploaded_field_label(field)).to eq 'label x'
+    end
+
+    it "should pull the label from the solr field" do
+      blacklight_config.add_index_field 'x', label: 'solr x'
+      expect(helper.uploaded_field_label(field)).to eq 'solr x'
+    end
+  end
 end

--- a/spec/models/spotlight/resources/upload_spec.rb
+++ b/spec/models/spotlight/resources/upload_spec.rb
@@ -35,6 +35,27 @@ describe Spotlight::Resources::Upload, :type => :model do
       expect(subject.to_solr[Spotlight::Engine.config.uploaded_attribution_field]).to eq "Attribution Data"
       expect(subject.to_solr[Spotlight::Engine.config.uploaded_date_field]).to eq "Date Data"
     end
+
+    context "multiple solr field mappings" do
+
+      let :configured_fields do
+        [
+          OpenStruct.new(field_name: 'some_field', solr_field: ['a', 'b'])
+        ]
+      end
+
+      before do
+        allow(subject).to receive(:configured_fields).and_return configured_fields
+
+        subject.data = { 'some_field' => 'value'}
+      end
+
+      it "should map a single uploaded field to multiple solr fields" do
+        expect(subject.to_solr['a']).to eq 'value'
+        expect(subject.to_solr['b']).to eq 'value'
+      end
+    end
+
     it 'should have a spotlight_resource_type field' do
       expect(subject.to_solr[:spotlight_resource_type_ssim]).to eq 'spotlight/resources/uploads'
     end

--- a/spec/models/spotlight/resources/upload_spec.rb
+++ b/spec/models/spotlight/resources/upload_spec.rb
@@ -24,12 +24,26 @@ describe Spotlight::Resources::Upload, :type => :model do
         end
       )
     end
+
     it 'should have the exhibit id and the upload id as the solr id' do
       expect(subject.to_solr[:id]).to eq "#{subject.exhibit.id}-#{subject.id}"
     end
     it 'should have a title field using the exhibit specific blacklight_config' do
       expect(subject.to_solr[:configured_title_field]).to eq 'Title Data'
     end
+
+    context "with a custom upload title field" do
+      let(:custom_title_field) { OpenStruct.new(field_name: :configured_title_field, solr_field: :some_other_field) }
+
+      before do
+        allow(Spotlight::Engine.config).to receive(:upload_title_field).and_return(custom_title_field)
+      end
+
+      it "should store the title field in the provided solr field" do
+        expect(subject.to_solr[:some_other_field]).to eq "Title Data"
+      end
+    end
+
     it 'should have the other additional configured fields' do
       expect(subject.to_solr[Spotlight::Engine.config.uploaded_description_field]).to eq "Description Data"
       expect(subject.to_solr[Spotlight::Engine.config.uploaded_attribution_field]).to eq "Attribution Data"

--- a/spec/views/spotlight/catalog/_edit_default.html.erb_spec.rb
+++ b/spec/views/spotlight/catalog/_edit_default.html.erb_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe "spotlight/catalog/_edit_default.html.erb", :type => :view do
-  let(:blacklight_config) {
+  let(:blacklight_config) do
     Blacklight::Configuration.new do |config|
       config.index.title_field = :title_field
     end
-  }
+  end
 
   let(:document) { stub_model(::SolrDocument) }
 
@@ -14,6 +14,9 @@ describe "spotlight/catalog/_edit_default.html.erb", :type => :view do
   before do
     allow(exhibit).to receive_messages(blacklight_config: blacklight_config)
 
+    allow(view).to receive(:uploaded_field_label) do |config|
+      "#{config.field_name} label"
+    end
     allow(view).to receive_messages(exhibit_tags_path: "autocomplete-path.json")
     allow(view).to receive_messages(blacklight_config: blacklight_config)
     allow(view).to receive_messages(current_exhibit: exhibit)
@@ -28,17 +31,17 @@ describe "spotlight/catalog/_edit_default.html.erb", :type => :view do
   end
   it 'should not have special metadata editing fields for non-uploaded resources' do
     render
-    expect(rendered).to_not have_field 'Title'
-    expect(rendered).to_not have_field 'Description'
-    expect(rendered).to_not have_field 'Attribution'
-    expect(rendered).to_not have_field 'Date'
+    expect(rendered).to_not have_field 'title_field label'
+    expect(rendered).to_not have_field 'spotlight_upload_description_tesim label'
+    expect(rendered).to_not have_field 'spotlight_upload_attribution_tesim label'
+    expect(rendered).to_not have_field 'spotlight_upload_date_tesim label'
   end
   it 'should have special metadata fields for an uploaded resource' do
     allow(document).to receive_messages(:uploaded_resource? => true)
     render
-    expect(rendered).to have_field 'Title'
-    expect(rendered).to have_field 'Description'
-    expect(rendered).to have_field 'Attribution'
-    expect(rendered).to have_field 'Date'
+    expect(rendered).to have_field 'title_field label'
+    expect(rendered).to have_field 'spotlight_upload_description_tesim label'
+    expect(rendered).to have_field 'spotlight_upload_attribution_tesim label'
+    expect(rendered).to have_field 'spotlight_upload_date_tesim label'
   end
 end


### PR DESCRIPTION
fixes #934, by allowing applications to map uploaded fields to multiple fields (e.g. a display field and an indexed, searched field)