### PR TITLE
Replace activemodel-serializers with roar

### DIFF
--- a/app/assets/javascripts/spotlight/blocks/search_result_block.js
+++ b/app/assets/javascripts/spotlight/blocks/search_result_block.js
@@ -71,7 +71,7 @@ SirTrevor.Blocks.SearchResults =  (function(){
   },
 
   loadViewTypes: function(){
-    var view_types_url = $('form[data-available-configurations-endpoint]').data('available-configurations-endpoint');
+    var view_types_url = $('form[data-available-search-views-endpoint]').data('available-search-views-endpoint');
     var selected_view_types = this.processSelectedViewTypes(this.viewTypesArea().data("select-after-ajax"));
     var block = this;
     $.ajax({
@@ -79,7 +79,7 @@ SirTrevor.Blocks.SearchResults =  (function(){
       url: view_types_url
     }).success(function(data){
       var checkboxes = "";
-      $.each(data.view, function(view_type, opts){
+      $.each(data, function(i, view_type){
         checkboxes += "<div>";
           checkboxes += "<label for='" + block.formId(view_type) + "'>";
             checkboxes += "<input id='" + block.formId(view_type) + "' name='" + view_type + "' type='checkbox' " + block.checkViewType(view_type) + " /> ";

--- a/app/assets/javascripts/spotlight/blocks/search_result_block.js
+++ b/app/assets/javascripts/spotlight/blocks/search_result_block.js
@@ -6,7 +6,7 @@ SirTrevor.Blocks.SearchResults =  (function(){
 
   return Spotlight.Block.extend({
 
-  searches_key: "searches-options",
+  searches_key: "slug",
 
   view_types_key: '[data-behavior="result-view-types"]',
 
@@ -57,7 +57,7 @@ SirTrevor.Blocks.SearchResults =  (function(){
       if($("option", searches_field).length == 1){
         var options = "";
         $.each(data, function(i, search){
-          options += "<option value='" + search.id + "'>" + search.title + "</option>";
+          options += "<option value='" + search.slug + "'>" + search.title + "</option>";
         });
 
         searches_field.append(options);

--- a/app/controllers/spotlight/blacklight_configurations_controller.rb
+++ b/app/controllers/spotlight/blacklight_configurations_controller.rb
@@ -25,9 +25,9 @@ class Spotlight::BlacklightConfigurationsController < Spotlight::ApplicationCont
     end
   end
 
-  def available_configurations
+  def available_search_views
     respond_to do |format|
-      format.json { render json: @blacklight_configuration.default_blacklight_config }
+      format.json { render json: @blacklight_configuration.default_blacklight_config.view.to_h.reject { |k,v| v.if === false}.keys }
     end
   end
 

--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -14,7 +14,9 @@ class Spotlight::ExhibitsController < Spotlight::ApplicationController
   end
 
   def process_import
-    if @exhibit.import(JSON.parse(import_exhibit_params.read))
+    @exhibit.import(JSON.parse(import_exhibit_params.read))
+
+    if @exhibit.save
       redirect_to spotlight.exhibit_dashboard_path(@exhibit), notice: t(:'helpers.submit.exhibit.updated', model: @exhibit.class.model_name.human.downcase)
     else
       render action: :import

--- a/app/helpers/spotlight/pages_helper.rb
+++ b/app/helpers/spotlight/pages_helper.rb
@@ -49,8 +49,7 @@ module Spotlight
     end
     def get_search_widget_search_results block
       begin
-        search = Spotlight::Search.find(block.send(:'searches-options'))
-        get_search_results(search.query_params.with_indifferent_access.merge(params))
+        get_search_results(block.query_params.with_indifferent_access.merge(params))
       rescue ActiveRecord::RecordNotFound
         []
       end

--- a/app/models/sir_trevor_rails/blocks/search_results_block.rb
+++ b/app/models/sir_trevor_rails/blocks/search_results_block.rb
@@ -1,0 +1,15 @@
+module SirTrevorRails::Blocks
+  class SearchResultsBlock < SirTrevorRails::Block
+    def query_params
+      search.query_params
+    end
+
+    def search
+      @search ||= if slug
+        parent.exhibit.searches.find_by!(slug: slug)
+      elsif search_id = send(:'searches-options')
+        parent.exhibit.searches.find(search_id)
+      end
+    end
+  end
+end

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -5,7 +5,7 @@ module Spotlight::Ability
     user ||= ::User.new
 
     alias_action :process_import, to: :import
-    alias_action :edit_metadata_fields, :edit_facet_fields, :metadata_fields, :available_configurations, to: :update
+    alias_action :edit_metadata_fields, :edit_facet_fields, :metadata_fields, :available_search_views, to: :update
 
     if user.superadmin?
       can :manage, :all

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -80,22 +80,8 @@ class Spotlight::Exhibit < ActiveRecord::Base
   end
 
   def import hash
-    # remove the default browse category -- it might be in the import
-    # and we don't want to have a conflicting slug
-    if persisted? and hash.fetch("searches_attributes", []).any? { |x| x["slug"] == "all-exhibit-items"}
-      searches.where(slug: "all-exhibit-items").destroy_all
-      reload
-    end
-
-    if hash["owned_taggings_attributes"]
-      hash["owned_taggings_attributes"].each do |tagging|
-        tag = tagging.delete "tag_attributes"
-        tagging["context"] = "tags"
-        tagging["tag"] = ActsAsTaggableOn::Tag.find_or_create_by name: tag["name"]
-      end
-    end
-
-    update hash
+    Spotlight::ExhibitExportSerializer.prepare(self).from_hash(hash)
+    self
   end
 
   def solr_data

--- a/app/serializers/spotlight/exhibit_export_serializer.rb
+++ b/app/serializers/spotlight/exhibit_export_serializer.rb
@@ -1,27 +1,6 @@
 require 'roar/decorator'
 require 'roar/json'
 module Spotlight
-  class PageRepresenter < Roar::Decorator
-    include Roar::JSON
-    (Spotlight::Page.attribute_names - ['id', 'slug', 'scope', 'exhibit_id', 'parent_page_id', 'content']).each do |prop|
-      property prop
-    end
-
-    property :content, exec_context: :decorator
-
-    def content
-      represented.content.as_json.to_json
-    end
-
-    def content= content
-      represented.content = content
-    end
-  end
-
-  class NestedPageRepresenter < PageRepresenter
-    collection :child_pages, extend: NestedPageRepresenter
-  end
-
   class ConfigurationRepresenter < Roar::Decorator
     include Roar::JSON
 

--- a/app/serializers/spotlight/page_representer.rb
+++ b/app/serializers/spotlight/page_representer.rb
@@ -1,0 +1,25 @@
+require 'roar/decorator'
+require 'roar/json'
+module Spotlight
+  class PageRepresenter < Roar::Decorator
+    include Roar::JSON
+    (Spotlight::Page.attribute_names - ['id', 'slug', 'scope', 'exhibit_id', 'parent_page_id', 'content']).each do |prop|
+      property prop
+    end
+
+    property :content, exec_context: :decorator
+
+    def content
+      # get the sir-trevor objects as JSON, and then turn it into a string
+      represented.content.as_json.to_json
+    end
+
+    def content= content
+      represented.content = content
+    end
+  end
+
+  class NestedPageRepresenter < PageRepresenter
+    collection :child_pages, extend: NestedPageRepresenter
+  end
+end

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -5,7 +5,7 @@
                 :'metadata-url' => spotlight.exhibit_metadata_path(@page.exhibit, format: "json"),
                 :'autocomplete-url'=> spotlight.autocomplete_exhibit_catalog_index_path(@page.exhibit, format: "json"),
                 :'searches-endpoint' => spotlight.exhibit_searches_path(@page.exhibit, format: "json"),
-                :'available-configurations-endpoint' => spotlight.exhibit_available_configurations_path(@page.exhibit, format: "json"),
+                :'available-search-views-endpoint' => spotlight.exhibit_available_search_views_path(@page.exhibit, format: "json"),
                 :'preview-url' => spotlight.exhibit_preview_block_url(@page.exhibit)
               }
             }) do |f| %>

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "social-share-button", "~> 0.1.5"
   s.add_dependency "blacklight-oembed", ">= 0.0.3"
   s.add_dependency "devise", "~> 3.0"
-  s.add_dependency "active_model_serializers", "0.9.0"
+  s.add_dependency "roar-rails"
   s.add_dependency "faraday"
   s.add_dependency "faraday_middleware"
   s.add_dependency "nokogiri"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Spotlight::Engine.routes.draw do
     get 'edit/metadata', to: "blacklight_configurations#edit_metadata_fields"
     get 'edit/facets', to: "blacklight_configurations#edit_facet_fields"
     get 'metadata', to: 'blacklight_configurations#metadata_fields'
-    get 'available_configurations', to: 'blacklight_configurations#available_configurations'
+    get 'available_search_views', to: 'blacklight_configurations#available_search_views'
 
     blacklight_for :catalog, only: [:export]
 

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -6,7 +6,6 @@ require 'spotlight/rails/routes'
 require 'spotlight/utils'
 require 'friendly_id'
 require 'devise'
-require 'active_model_serializers'
 require 'tophat'
 
 module Spotlight

--- a/spec/controllers/spotlight/blacklight_configurations_controller_spec.rb
+++ b/spec/controllers/spotlight/blacklight_configurations_controller_spec.rb
@@ -83,11 +83,12 @@ describe Spotlight::BlacklightConfigurationsController, :type => :controller do
       end
     end
 
-    describe "#available_configurations" do
+    describe "#available_search_views" do
       it "should be successful" do
-        get :available_configurations, exhibit_id: exhibit, format: 'json'
+        get :available_search_views, exhibit_id: exhibit, format: 'json'
         expect(response).to be_successful
-        expect(JSON.parse(response.body).keys).to match_array exhibit.blacklight_config.keys.map(&:to_s)
+        available = JSON.parse(response.body)
+        expect(available).to match_array ['list', 'gallery', 'slideshow']
       end
     end
 

--- a/spec/features/import_exhibit_spec.rb
+++ b/spec/features/import_exhibit_spec.rb
@@ -17,7 +17,7 @@ describe "Allow exhibit admins to import and export content from an exhibit", :t
 
     data = JSON.parse(page.body)
 
-    expect(data).to include "title", "subtitle", "description", "searches_attributes", "home_page_attributes"
+    expect(data).to include "title", "searches", "home_page"
 
   end
 

--- a/spec/features/javascript/search_result_block_spec.rb
+++ b/spec/features/javascript/search_result_block_spec.rb
@@ -23,10 +23,10 @@ describe "Search Results Block", type: :feature, js: true do
     add_widget 'search_results'
 
     # Drop down should exist with all browse categories listed
-    within("select[name='searches-options']") do
+    within("select[name='slug']") do
       expect(page).to have_css("option", text: "All Exhibit Items", visible: true)
       expect(page).to have_css("option", text: "Alt. Search", visible: true)
-      expect(page).to have_css("option[value='#{alt_search.id}']", visible: true)
+      expect(page).to have_css("option[value='#{alt_search.slug}']", visible: true)
     end
 
     select("All Exhibit Items", from: "Browse category")

--- a/spec/helpers/spotlight/pages_helper_spec.rb
+++ b/spec/helpers/spotlight/pages_helper_spec.rb
@@ -39,8 +39,8 @@ module Spotlight
       end
     end
     describe "get_search_widget_search_results" do
-      let(:good) { SirTrevorRails::Block.new({type: 'xyz', data: {'searches-options' => search.id}}, 'parent') }
-      let(:bad) { SirTrevorRails::Block.new({type: 'xyz', data: { 'searches-options' => 100}}, 'parent') }
+      let(:good) { SirTrevorRails::Blocks::SearchResultsBlock.new({type: 'xyz', data: {'slug' => search.slug}}, home_page) }
+      let(:bad) { SirTrevorRails::Blocks::SearchResultsBlock.new({type: 'xyz', data: { 'slug' => 'missing'}}, home_page) }
       let(:search_result) { [double('response'), double('documents')] }
       it "should return the results for a given search browse category" do
         expect(helper).to receive(:get_search_results).with({"q" => "query"}).and_return(search_result)

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -68,20 +68,19 @@ describe Spotlight::Exhibit, :type => :model do
     it "should remove the default browse category" do
       subject.save
       expect { subject.import({}) }.to change {subject.searches.count}.by(0)
-      expect { subject.import({"searches_attributes" => [{"title" => "All Exhibit Items","slug" => "all-exhibit-items"}]}) }.to change {subject.searches.count}.by(0)
+      expect { subject.import({"searches" => [{"title" => "All Exhibit Items","slug" => "all-exhibit-items"}]}) }.to change {subject.searches.count}.by(0)
     end
 
     it "should import nested attributes from the hash" do
       subject.save
-      some_value = {}
-      expect(subject).to receive(:update).with(some_value)
-      subject.import some_value
+      subject.import 'title' => 'xyz'
+      expect(subject.title).to eq 'xyz'
     end
 
     it "should munge taggings so they can be imported easily" do
-      subject.save
       expect do
-        subject.import("owned_taggings_attributes"=>[{"taggable_type"=>"SolrDocument", "context"=>'tags', "created_at"=>"2015-01-16T18:23:27.340Z", "taggable_id"=>"1", "tag_attributes"=>{"name"=>"xyz"}}])
+        subject.import("owned_taggings"=>[{"taggable_id"=>"1", "taggable_type"=>"SolrDocument", "context"=>"tags", "tag"=>"xyz"}])
+        subject.save
       end.to change { subject.owned_taggings.count }.by(1)
       tag = subject.owned_taggings.last
       expect(tag.taggable_id).to eq "1"

--- a/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
+++ b/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
@@ -13,60 +13,106 @@ describe Spotlight::ExhibitExportSerializer do
   end
 
   it "should have search attributes" do
-    expect(subject["searches_attributes"]).to have(source_exhibit.searches.count).searches
+    expect(subject["searches"]).to have(source_exhibit.searches.count).searches
   end
 
   it "should have home page attributes" do
-    expect(subject).to have_key "home_page_attributes"
-    expect(subject['home_page_attributes']).to_not have_key 'id'
-    expect(subject['home_page_attributes']).to_not have_key 'scope'
-    expect(subject['home_page_attributes']).to_not have_key 'exhibit_id'
+    expect(subject).to have_key "home_page"
+    expect(subject['home_page']).to_not have_key 'id'
+    expect(subject['home_page']).to_not have_key 'scope'
+    expect(subject['home_page']).to_not have_key 'exhibit_id'
   end
 
   it "should have about pages" do
-    expect(subject["about_pages_attributes"]).to have(source_exhibit.about_pages.count).pages
+    expect(subject["about_pages"]).to have(source_exhibit.about_pages.count).pages
   end
 
   it "should have feature pages" do
-    expect(subject["feature_pages_attributes"]).to have(source_exhibit.feature_pages.at_top_level.count).pages
+    expect(subject["feature_pages"]).to have(source_exhibit.feature_pages.at_top_level.count).pages
   end
 
   it "should have custom fields" do
-    expect(subject["custom_fields_attributes"]).to have(source_exhibit.custom_fields.count).items
+    expect(subject["custom_fields"]).to have(source_exhibit.custom_fields.count).items
   end
 
   it "should have contacts" do
-    expect(subject["contacts_attributes"]).to have(source_exhibit.contacts.count).items
+    expect(subject["contacts"]).to have(source_exhibit.contacts.count).items
   end
 
   it "should have contact emails" do
-    expect(subject["contact_emails_attributes"]).to have(source_exhibit.contact_emails.count).items
+    expect(subject["contact_emails"]).to have(source_exhibit.contact_emails.count).items
   end
 
   it "should have blacklight configuration attributes" do
-    expect(subject).to have_key "blacklight_configuration_attributes"
+    expect(subject).to have_key "blacklight_configuration"
   end
 
   it "should have solr document sidecars" do
     source_exhibit.solr_document_sidecars.create! solr_document_id: 1, public: false
-    expect(subject["solr_document_sidecars_attributes"]).to have_at_least(1).item
-    expect(subject["solr_document_sidecars_attributes"]).to have(source_exhibit.solr_document_sidecars.count).items
+    expect(subject["solr_document_sidecars"]).to have_at_least(1).item
+    expect(subject["solr_document_sidecars"]).to have(source_exhibit.solr_document_sidecars.count).items
   
-    expect(subject["solr_document_sidecars_attributes"].first).to include('solr_document_id', 'public')
-    expect(subject["solr_document_sidecars_attributes"].first).to_not include 'id'
+    expect(subject["solr_document_sidecars"].first).to include('solr_document_id', 'public')
+    expect(subject["solr_document_sidecars"].first).to_not include 'id'
   end
 
   it "should have attachments" do
-    expect(subject["attachments_attributes"]).to have(source_exhibit.attachments.count).items
+    expect(subject["attachments"]).to have(source_exhibit.attachments.count).items
   end
 
   it "should have resources" do
-    expect(subject["resources_attributes"]).to have(source_exhibit.resources.count).items
+    expect(subject["resources"]).to have(source_exhibit.resources.count).items
   end
 
   it "should have tags" do
     source_exhibit.tag(SolrDocument.new(id: 1), with: "xyz", on: :tags)
-    expect(subject["owned_taggings_attributes"]).to have(source_exhibit.owned_taggings.count).items
+    expect(subject["owned_taggings"]).to have(source_exhibit.owned_taggings.count).items
+  end
+
+  describe "should round-trip data" do
+    before do
+      source_exhibit.solr_document_sidecars.create! solr_document_id: 1, public: false
+      source_exhibit.tag(SolrDocument.new(id: 1), with: "xyz", on: :tags)
+    end
+
+    let :export do
+      Spotlight::ExhibitExportSerializer.new(source_exhibit).as_json
+    end
+
+    subject do
+      e = FactoryGirl.create(:exhibit)
+      e.import(export).tap { |e| e.save }
+    end
+
+    it "should have exhibit properties" do
+      expect(subject.title).to eq source_exhibit.title
+    end
+
+    it "should not duplicate saved searches" do
+      expect(subject.searches).to have(1).item
+    end
+
+    it "should have blacklight configuration properties" do
+      expect(subject.blacklight_configuration).to be_persisted
+    end
+
+    it "should have home page properties" do
+      expect(subject.home_page).to be_persisted
+      expect(subject.home_page.id).not_to eq source_exhibit.home_page.id
+
+      expect(subject.home_page.title).to eq source_exhibit.home_page.title
+      expect(subject.home_page.content).to eq source_exhibit.home_page.content
+    end
+
+    it "should have sidecars" do
+      expect(SolrDocument.new(id: 1).public? subject).to be_falsey
+    end
+
+    it "should have tags" do
+      expect(subject.owned_taggings.length).to eq source_exhibit.owned_taggings.length
+      expect(subject.owned_taggings.first).to be_persisted
+      expect(subject.owned_taggings.first.tag.name).to eq "xyz"
+    end
   end
 
 end


### PR DESCRIPTION
Fixes #894 

I've configured `roar` to just replace all data with the provided import. I think that's closer to our use-case than the previous behavior was anyway.

Fixes #939 
Fixes #698 