### PR TITLE
After adding an item to the exhibit, force a solr commit and return the ...

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -196,4 +196,12 @@ class Spotlight::CatalogController < ::CatalogController
       end
     end
   end
+
+  # calls setup_previous_document then setup_next_document.
+  # used in the show action for single view pagination.
+  def setup_next_and_previous_documents
+    super
+  rescue RSolr::Error::Http => e
+    Rails.logger.warn "Unable to setup next and previous documents: #{e}"
+  end
 end

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -51,7 +51,10 @@ class Spotlight::CatalogController < ::CatalogController
   def admin
     self.blacklight_config.view.select! { |k,v| k == :admin_table }
     self.blacklight_config.view.admin_table.partials = [:index_compact]
-    self.blacklight_config.sort_fields.reject! { |k,v| true }
+
+    unless self.blacklight_config.sort_fields.has_key? :timestamp
+      self.blacklight_config.add_sort_field :timestamp, sort: "#{blacklight_config.index.timestamp_field} desc"
+    end
 
     add_breadcrumb t(:'spotlight.curation.sidebar.header'), exhibit_dashboard_path(@exhibit)
     add_breadcrumb t(:'spotlight.curation.sidebar.items'), admin_exhibit_catalog_index_path(@exhibit)

--- a/app/controllers/spotlight/resources/upload_controller.rb
+++ b/app/controllers/spotlight/resources/upload_controller.rb
@@ -14,16 +14,16 @@ module Spotlight::Resources
     def create
       @resource.attributes = resource_params
 
-      if @resource.save
+      if @resource.save_and_commit
         flash[:notice] = t('spotlight.resources.upload.success')
         if params["add-and-continue"]
           redirect_to new_exhibit_resources_upload_path(@resource.exhibit)
         else
-          redirect_to admin_exhibit_catalog_index_path(@resource.exhibit)
+          redirect_to admin_exhibit_catalog_index_path(@resource.exhibit, sort: :timestamp)
         end
       else
         flash[:error] = t('spotlight.resources.upload.error')
-        redirect_to admin_exhibit_catalog_index_path(@resorce.exhibit)
+        redirect_to admin_exhibit_catalog_index_path(@resource.exhibit, sort: :timestamp)
       end
     end
 

--- a/app/controllers/spotlight/resources_controller.rb
+++ b/app/controllers/spotlight/resources_controller.rb
@@ -25,11 +25,11 @@ module Spotlight
       @resource.attributes = resource_params
       @resource = @resource.becomes_provider
 
-      if @resource.save
+      if @resource.save_and_commit
         if from_popup?
           render layout: false, text: "<html><script>window.close();</script></html>"
         else
-          redirect_to admin_exhibit_catalog_index_path(@resource.exhibit)
+          redirect_to admin_exhibit_catalog_index_path(@resource.exhibit, sort: :timestamp)
         end
       else
         render action: 'new'

--- a/app/models/spotlight/resource.rb
+++ b/app/models/spotlight/resource.rb
@@ -70,6 +70,10 @@ module Spotlight
       type.blank?
     end
 
+    def save_and_commit
+      save.tap { blacklight_solr.commit rescue nil }
+    end
+
     protected
 
     def blacklight_solr

--- a/spec/controllers/spotlight/resources/upload_controller_spec.rb
+++ b/spec/controllers/spotlight/resources/upload_controller_spec.rb
@@ -47,10 +47,15 @@ describe Spotlight::Resources::UploadController, :type => :controller do
 
     describe "POST create" do
 
+      let(:blacklight_solr) { double }
+
       before do
+        allow(blacklight_solr).to receive(:commit)
         allow_any_instance_of(Spotlight::Resource).to receive(:reindex)
+        allow_any_instance_of(Spotlight::Resource).to receive(:blacklight_solr).and_return blacklight_solr
       end
       it "create a Spotlight::Resources::Upload resource" do
+        expect(blacklight_solr).to receive(:commit)
         post :create, exhibit_id: exhibit, resources_upload: { url: "url-data" }
         expect(assigns[:resource]).to be_persisted
         expect(assigns[:resource]).to be_a(Spotlight::Resources::Upload)
@@ -58,7 +63,7 @@ describe Spotlight::Resources::UploadController, :type => :controller do
       it 'should redirect to the item admin page' do
         post :create, exhibit_id: exhibit, resources_upload: { url: "url-data" }
         expect(flash[:notice]).to eq 'Object uploaded successfully.'
-        expect(response).to redirect_to admin_exhibit_catalog_index_path(exhibit)
+        expect(response).to redirect_to admin_exhibit_catalog_index_path(exhibit, sort: :timestamp)
       end
       it 'should redirect to the upload form when the add-and-continue parameter is present' do
         post :create, exhibit_id: exhibit, "add-and-continue" => "true", resources_upload: { url: "url-data" }

--- a/spec/controllers/spotlight/resources_controller_spec.rb
+++ b/spec/controllers/spotlight/resources_controller_spec.rb
@@ -47,8 +47,11 @@ describe Spotlight::ResourcesController, :type => :controller do
     end
 
     describe "POST create" do
+      let(:blacklight_solr) { double }
       it "create a resource" do
         allow_any_instance_of(Spotlight::Resource).to receive(:reindex)
+        expect(blacklight_solr).to receive(:commit)
+        allow_any_instance_of(Spotlight::Resource).to receive(:blacklight_solr).and_return blacklight_solr
         post :create, exhibit_id: exhibit, resource: { url: "info:uri" }
         expect(assigns[:resource]).to be_persisted
       end

--- a/spec/models/spotlight/resource_spec.rb
+++ b/spec/models/spotlight/resource_spec.rb
@@ -79,4 +79,12 @@ describe Spotlight::Resource, :type => :model do
       subject.update_index_time!
     end
   end
+
+  describe "#save_and_commit" do
+    it "should save the object and commit to solr" do
+      expect(subject).to receive(:save)
+      expect(subject.send(:blacklight_solr)).to receive(:commit)
+      subject.save_and_commit
+    end
+  end
 end


### PR DESCRIPTION
...user to the admin page sorted by timestamp.

Hopefully this will make the flow of add item => admin catalog page make more sense.

![untitled](https://cloud.githubusercontent.com/assets/111218/6258449/71784ed4-b77d-11e4-8740-c9bed13cf226.gif)
