### PR TITLE
Add exhibit-specific analytics dashboard

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibit_admin.scss
+++ b/app/assets/stylesheets/spotlight/_exhibit_admin.scss
@@ -65,3 +65,23 @@
 
   .form-control-static { display: none; }
 }
+
+.analytics {
+  text-align: center;
+
+  & > tfoot > tr > th {
+    padding-top: 0;
+    border-top: 0;
+    text-align: center;
+  }
+
+  th, td {
+    &:first-child {
+      border-left: 0;
+    }
+
+    border-left: 1px solid $table-border-color;
+  }
+
+  border-bottom: 1px solid $table-border-color;
+}

--- a/app/models/spotlight/analytics/ga.rb
+++ b/app/models/spotlight/analytics/ga.rb
@@ -1,0 +1,65 @@
+module Spotlight
+  module Analytics
+    class Ga
+      require 'legato'
+
+      extend Legato::Model
+
+      cattr_accessor :pkcs12_key_path, :email, :web_property_id
+      cattr_writer :user, :site
+
+      metrics :sessions, :users, :pageviews
+
+      def self.enabled?
+        user && site
+      end
+
+      def self.for_exhibit exhibit
+        path(Spotlight::Engine.routes.url_helpers.exhibit_path(exhibit))
+      end
+
+      filter :path, &lambda { |path| contains(:pagePath, "^#{path}") }
+          
+      def self.user(scope="https://www.googleapis.com/auth/analytics.readonly")
+        @user ||= begin
+          require 'oauth2'
+          require 'google/api_client'
+
+          client = Google::APIClient.new(
+            application_name: "spotlight",
+            application_version: Spotlight::VERSION
+          )
+          key = Google::APIClient::PKCS12.load_key(pkcs12_key_path, "notasecret")
+          service_account = Google::APIClient::JWTAsserter.new(email, scope, key)
+          client.authorization = service_account.authorize
+          oauth_client = OAuth2::Client.new("", "", {
+            authorize_url: 'https://accounts.google.com/o/oauth2/auth',
+            token_url: 'https://accounts.google.com/o/oauth2/token'
+          })
+          token = OAuth2::AccessToken.new(oauth_client, client.authorization.access_token, expires_in: 1.hour)
+          Legato::User.new(token)
+        rescue => e
+          Rails.logger.info(e)
+          nil
+        end
+      end
+
+      def self.site
+        @site ||= user.accounts.first.profiles.first { |x| x.web_property_id = web_property_id }
+      end
+
+      def self.exhibit_data exhibit, options
+        self.for_exhibit(exhibit).results(site, options).to_a.first || OpenStruct.new(pageviews: 0, users: 0, sessions: 0)
+      end
+
+      def self.page_data exhibit, options
+        options[:sort] ||= '-pageviews'
+        query = self.for_exhibit(exhibit).results(site, options)
+        query.dimensions << :page_path
+        query.dimensions << :page_title
+
+        query.to_a
+      end
+    end
+  end
+end

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -106,6 +106,18 @@ class Spotlight::Exhibit < ActiveRecord::Base
     Spotlight::Appearance.new(blacklight_configuration)
   end
 
+  def analytics start_date = 1.month
+    @analytics ||= begin
+      Spotlight::Analytics::Ga.exhibit_data(self, start_date: start_date.ago)
+    end
+  end
+  
+  def page_analytics start_date = 1.month
+    @page_analytics ||= begin
+      Spotlight::Analytics::Ga.page_data(self, start_date: start_date.ago)
+    end
+  end
+
   protected
 
   def initialize_config

--- a/app/views/spotlight/dashboards/_analytics.html.erb
+++ b/app/views/spotlight/dashboards/_analytics.html.erb
@@ -1,0 +1,36 @@
+<%= cache current_exhibit, expires_in: 1.hour do %>
+<% if Spotlight::Analytics::Ga.enabled? %>
+  <h3><%= t :'.header' %></h3>
+  <table class="table analytics">
+    <tr>
+    <% Spotlight::Analytics::Ga.metrics.elements.each do |e| %>
+        <td class="value col-md-3 <%= e %>"><%= current_exhibit.analytics.send(e) %></td>
+    <% end %>
+    </tr>
+    <tfoot>
+      <tr>
+      <% Spotlight::Analytics::Ga.metrics.elements.each do |e| %>
+        <th><%= t(:".#{e}") %></th>
+      <% end %>
+      </tr>
+    </tfoot>
+  </table>
+  <% unless current_exhibit.page_analytics.empty? %>
+  <h4><%= t :'.pages.header' %></h4>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th><%= t(:".pagetitle") %></th>
+        <th><%= t(:".pageviews") %></th>
+      </tr>
+    </thead>
+    <% current_exhibit.page_analytics.each do |p| %>
+      <tr>
+        <td><%= link_to p.pageTitle, p.pagePath %></td>
+        <td><%= p.pageviews %></td>
+      </tr>
+    <% end %>
+  </table>
+  <% end %>
+<% end %>
+<% end %>

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -39,6 +39,9 @@ Gem::Specification.new do |s|
   s.add_dependency "github-markup"
   s.add_dependency "lodash-rails"
   s.add_dependency "tophat"
+  s.add_dependency "legato"
+  s.add_dependency "google-api-client"
+  s.add_dependency "oauth2"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 3.1"

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -238,6 +238,14 @@ en:
           updated_at: Last Edited
       solr_document_activity:
         header: Recently Updated Items
+      analytics:
+        header: "User Activity Over the Past Month"
+        pageviews: "page views"
+        users: "unique visits"
+        sessions: "visitors"
+        pagetitle: "page title"
+        pages:
+          header: "Most popular pages"
     exhibits:
       breadcrumb: Home
       edit:

--- a/spec/models/spotlight/analytics/ga_spec.rb
+++ b/spec/models/spotlight/analytics/ga_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Spotlight::Analytics::Ga do
+  it "should not be enabled without configuration" do
+    expect(described_class.enabled?).to be_falsey
+  end
+end

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -120,4 +120,31 @@ describe Spotlight::Exhibit, :type => :model do
     end
   end
 
+  describe "#analytics" do
+    subject { FactoryGirl.create(:exhibit) }
+    let(:ga_data) { OpenStruct.new(pageviews: 123)}
+
+    before do
+      allow(Spotlight::Analytics::Ga).to receive(:exhibit_data).with(subject, hash_including(:start_date)).and_return(ga_data)
+    end
+
+    it "should request analytics data" do
+      expect(subject.analytics.pageviews).to eq 123
+    end
+  end
+
+  describe "#page_analytics" do
+    subject { FactoryGirl.create(:exhibit) }
+    let(:ga_data) { [OpenStruct.new(pageviews: 123)]}
+
+    before do
+      allow(Spotlight::Analytics::Ga).to receive(:page_data).with(subject, hash_including(:start_date)).and_return(ga_data)
+    end
+
+    it "should request analytics data" do
+      expect(subject.page_analytics.length).to eq 1
+      expect(subject.page_analytics.first.pageviews).to eq 123
+    end
+  end
+
 end

--- a/spec/views/spotlight/dashboards/_analytics.html.erb_spec.rb
+++ b/spec/views/spotlight/dashboards/_analytics.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'spotlight/dashboards/_analytics.html.erb', type: :view do
+  let(:current_exhibit) { FactoryGirl.create(:exhibit) }
+  let(:ga_data) { OpenStruct.new(pageviews: 1, users: 2, sessions: 3)}
+  let(:page_data) { [ OpenStruct.new(pageTitle: "title", pagePath: "/path", pageviews: '123') ]}
+  before do
+    allow(view).to receive_messages(current_exhibit: current_exhibit)
+    allow(Spotlight::Analytics::Ga).to receive(:enabled?).and_return(true)
+    allow(current_exhibit).to receive(:analytics).and_return(ga_data)
+    allow(current_exhibit).to receive(:page_analytics).and_return(page_data)
+  end
+  
+  it "should have header" do
+    render
+    expect(rendered).to have_content "User Activity Over the Past Month"
+  end
+
+  it "should have metric labels" do
+    render
+    expect(rendered).to have_content "visitors"
+    expect(rendered).to have_content "unique visits"
+    expect(rendered).to have_content "page views"
+  end
+
+  it "should have metric values" do
+    render
+    expect(rendered).to have_selector ".value.pageviews", text: 1
+    expect(rendered).to have_selector ".value.users", text: 2
+    expect(rendered).to have_selector ".value.sessions", text: 3
+  end
+
+  it "should have page-level data" do
+    render
+    expect(rendered).to have_content "Most popular pages"
+    expect(rendered).to have_link "title", href: "/path"
+    expect(rendered).to have_content "123"
+  end
+end


### PR DESCRIPTION
Fixes #303 

![screen shot 2015-02-19 at 7 49 53 am](https://cloud.githubusercontent.com/assets/111218/6270032/e9e935ca-b80b-11e4-81f1-4ed742863758.png)
