### PR TITLE
Use ::Rails::Html::FullSanitizer in exhibit description sanitization.

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -113,7 +113,7 @@ class Spotlight::Exhibit < ActiveRecord::Base
   end
 
   def sanitize_description
-    self.description = HTML::FullSanitizer.new.sanitize(description) if description_changed?
+    self.description = ::Rails::Html::FullSanitizer.new.sanitize(description) if description_changed?
   end
 
   def default_main_navigations


### PR DESCRIPTION
Fixes #945 ?

Not sure why `HTML::FullSanitizer` works under rspec but it fails when trying to create a new exhibit through the UI.

According to https://github.com/rails/rails-html-sanitizer#usage the appropriate way to invoke the sanitizer is `Rails::Html::FullSanitizer.new`.