### PR TITLE
Add undo/redo support for feature, about, and home pages using paper_trail

### DIFF
--- a/app/controllers/spotlight/application_controller.rb
+++ b/app/controllers/spotlight/application_controller.rb
@@ -5,5 +5,9 @@ module Spotlight
   # This will configure e.g. the layout used by the host
   class ApplicationController < ::ApplicationController
     include Spotlight::Concerns::ApplicationController
+
+    before_filter do
+      flash.now[:notice] = flash[:notice].html_safe if flash[:html_safe] && flash[:notice]
+    end
   end
 end

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -54,7 +54,7 @@ module Spotlight
       @page.lock.delete if @page.lock
 
       if @page.update(page_params.merge(last_edited_by: current_user))
-        redirect_to [@page.exhibit, @page], notice: t(:'helpers.submit.page.updated', model: @page.class.model_name.human.downcase)
+        redirect_to [@page.exhibit, @page], flash: { html_safe: true }, notice: view_context.safe_join([t(:'helpers.submit.page.updated', model: @page.class.model_name.human.downcase), undo_link], " ")
       else
         render action: 'edit'
       end
@@ -64,7 +64,7 @@ module Spotlight
     def destroy
       @page.destroy
 
-      redirect_to [@page.exhibit, page_collection_name], notice: t(:'helpers.submit.page.destroyed', model: @page.class.model_name.human.downcase)
+      redirect_to [@page.exhibit, page_collection_name], flash: { html_safe: true }, notice: view_context.safe_join([t(:'helpers.submit.page.destroyed', model: @page.class.model_name.human.downcase), undo_link], " ")
     end
 
     def update_all
@@ -78,6 +78,11 @@ module Spotlight
 
     def _prefixes
       @_prefixes ||= super + ['catalog']
+    end
+
+    def undo_link
+      return unless can? :manage, @page
+      view_context.link_to(t(:'spotlight.versions.undo'), revert_version_path(@page.versions.last), :method => :post)
     end
 
     protected

--- a/app/controllers/spotlight/versions_controller.rb
+++ b/app/controllers/spotlight/versions_controller.rb
@@ -1,0 +1,33 @@
+module Spotlight
+  class VersionsController < Spotlight::ApplicationController
+    before_filter :authenticate_user!
+
+    load_and_authorize_resource class: "PaperTrail::Version"
+
+    def revert
+      if obj = @version.reify
+        authorize! :manage, obj
+        if obj.save
+          redirect_to [obj.exhibit, obj], flash: { html_safe: true }, notice: undo_link
+        else
+          redirect_to [obj.exhibit, obj], flash: { html_safe: true }, notice: view_context.t(:'spotlight.versions.undo_error')
+        end
+      else
+        redirect_to :back, flash: { html_safe: true }, notice: view_context.t(:'spotlight.versions.undo_error')
+      end
+
+    end
+
+    def undo_link
+      return unless can? :manage, @version
+
+      link_name = if params[:redo] == "true"
+        view_context.t(:'spotlight.versions.undo')
+      else
+        view_context.t(:'spotlight.versions.redo')
+      end
+
+      view_context.link_to(link_name, revert_version_path(@version.next, :redo => !params[:redo]), method: :post)
+    end
+  end
+end

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -16,6 +16,10 @@ module Spotlight::Ability
     can :manage, Spotlight::Role, exhibit_id: user.admin_roles.pluck(:exhibit_id)
     can :update, Spotlight::Appearance, exhibit_id: user.admin_roles.pluck(:exhibit_id)
 
+    if user.roles.any?
+      can :manage, PaperTrail::Version
+    end
+
     # exhibit curator
     can :manage, [
       Spotlight::Attachment,

--- a/app/models/spotlight/page.rb
+++ b/app/models/spotlight/page.rb
@@ -17,6 +17,7 @@ module Spotlight
 
     has_one :lock, as: :on, dependent: :destroy
     sir_trevor_content :content
+    has_paper_trail
 
     # display_sidebar should be set to true by default
     before_create do

--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -9,6 +9,7 @@ class Spotlight::Search < ActiveRecord::Base
   default_scope { order("weight ASC") }
   scope :published, -> { where(on_landing_page: true) }
   validates :title, presence: true
+  has_paper_trail
 
   before_create do
     self.featured_item_id ||= default_featured_item_id

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency "legato"
   s.add_dependency "google-api-client"
   s.add_dependency "oauth2"
+  s.add_dependency "paper_trail", '~> 4.0.0.beta'
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 3.1"

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -434,6 +434,10 @@ en:
         body:
           one: "%{count} document has been indexed from the CSV file and added to the exhibit %{title}."
           other: "%{count} documents have been indexed from the CSV file and added to the exhibit %{title}."
+    versions:
+      undo: Undo changes
+      redo: Redo changes
+      undo_error: Unable to undo changes
   shared:
     exhibit_masthead:
       more_exhibits: More Exhibits

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,9 @@ Spotlight::Engine.routes.draw do
         patch :update_all
       end
     end
+
   end
 
+  post 'versions/:id/revert' => 'versions#revert', as: :revert_version
   get '/:exhibit_id' => 'home_pages#show', as: :exhibit_root
 end

--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -21,6 +21,10 @@ module Spotlight
       generate "friendly_id"
     end
 
+    def paper_trail
+      generate 'paper_trail:install'
+    end
+
     def assets
       copy_file "spotlight.scss", "app/assets/stylesheets/spotlight.scss"
       copy_file "spotlight.js", "app/assets/javascripts/spotlight.js"

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -7,6 +7,7 @@ require 'spotlight/utils'
 require 'friendly_id'
 require 'devise'
 require 'tophat'
+require 'paper_trail'
 
 module Spotlight
   class Engine < ::Rails::Engine

--- a/spec/controllers/spotlight/about_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/about_pages_controller_spec.rb
@@ -95,6 +95,7 @@ describe Spotlight::AboutPagesController, :type => :controller do
         put :update, id: page, exhibit_id: page.exhibit.id, about_page: valid_attributes
         page.reload
         expect(response).to redirect_to(exhibit_about_page_path(page.exhibit, page))
+        expect(flash[:notice]).to have_link "Undo changes"
       end
     end
     describe "POST update_all" do

--- a/spec/controllers/spotlight/feature_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/feature_pages_controller_spec.rb
@@ -124,6 +124,7 @@ describe Spotlight::FeaturePagesController, :type => :controller do
           put :update, id: page, exhibit_id: page.exhibit.id, feature_page: valid_attributes
           page.reload
           expect(response).to redirect_to(exhibit_feature_page_path(page.exhibit, page))
+          expect(flash[:notice]).to have_link "Undo changes"
         end
       end
 

--- a/spec/controllers/spotlight/home_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/home_pages_controller_spec.rb
@@ -42,6 +42,7 @@ describe Spotlight::HomePagesController, :type => :controller do
         put :update, id: page, exhibit_id: page.exhibit.id, home_page: valid_attributes
         page.reload
         expect(response).to redirect_to(exhibit_home_page_path(page.exhibit, page))
+        expect(flash[:notice]).to have_link "Undo changes"
       end
     end
   end

--- a/spec/controllers/spotlight/versions_controller_spec.rb
+++ b/spec/controllers/spotlight/versions_controller_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Spotlight::VersionsController, type: :controller do
+ 
+  routes { Spotlight::Engine.routes } 
+
+  describe "when not logged in" do
+    describe "POST revert" do
+      it "should not be allowed" do
+        post :revert, id: 1
+        expect(response).to redirect_to main_app.new_user_session_path
+      end
+    end
+  end
+  
+  describe "when not authorized for the exhibit resource" do
+    
+    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    let(:user) { FactoryGirl.create(:exhibit_visitor) }
+    let!(:page) { FactoryGirl.create(:feature_page, exhibit: exhibit) }
+    before do
+      sign_in user
+    end
+
+    describe "POST revert" do
+      it "should not be allowed" do
+        post :revert, id: page.versions.last
+        expect(response).to redirect_to main_app.root_path
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe "when logged in as a curator" do
+    
+    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    let(:user) { FactoryGirl.create(:exhibit_curator) }
+    let!(:page) { FactoryGirl.create(:feature_page, exhibit: exhibit) }
+    before do
+      FactoryGirl.create(:role, exhibit: exhibit, user: user)
+      sign_in user
+    end
+
+    describe "POST revert" do
+      it "should revert the change" do
+        page.title = "xyz"
+        page.save!
+
+        post :revert, id: page.versions.last
+        page.reload
+        expect(page.title).not_to eq "xyz"
+        expect(response).to redirect_to [exhibit, page]
+        expect(flash[:notice]).to be_present
+        expect(flash[:notice]).to match /Redo changes/
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #492 

![undo-redo](https://cloud.githubusercontent.com/assets/111218/6309194/90735c6a-b8ff-11e4-9853-ef86943cc969.gif)
