### PR TITLE
Replace image width and height values with calculated values

### DIFF
--- a/app/assets/stylesheets/spotlight/_featured_browse_categories_block.scss
+++ b/app/assets/stylesheets/spotlight/_featured_browse_categories_block.scss
@@ -1,12 +1,35 @@
 $featured-browse-category-border-color: $legend-border-color;
 $featured-browse-category-caption-color: $gray-lighter;
-$smallest-featured-browse-category-width: 220px;
-$smallest-featured-browse-category-height: $smallest-featured-browse-category-width;
-$largest-featured-browse-category-height: 255px;
-$no-sidebar-medium-image-width: 300px;
-$no-sidebar-large-image-width: 360px;
-$with-sidebar-medium-image-width: 340px;
-$with-sidebar-large-image-width: $no-sidebar-large-image-width;
+
+// Large desktop
+$featured-browse-category-margin-large-desktop: 15px;
+$no-sidebar-large-desktop-large-image-width: floor(($container-large-desktop)/ 3) - $featured-browse-category-margin-large-desktop;
+$no-sidebar-large-desktop-medium-image-width: floor(($container-large-desktop)/ 5) - $featured-browse-category-margin-large-desktop;
+
+$with-sidebar-large-desktop-width: floor($container-large-desktop - ($container-large-desktop)/ 4);  // sidebar space to remove
+$with-sidebar-large-desktop-large-image-width: floor(($with-sidebar-large-desktop-width)/ 2) - ($featured-browse-category-margin-large-desktop * 2);
+$with-sidebar-large-desktop-medium-image-width: 265px;
+
+// Desktop
+$featured-browse-category-margin-desktop: 20px;
+$no-sidebar-desktop-large-image-width: floor(($container-desktop)/ 3) - $featured-browse-category-margin-desktop;
+
+$with-sidebar-desktop-width: floor($container-desktop - ($container-desktop)/ 4);  // sidebar space to remove
+$with-sidebar-desktop-large-image-width: floor(($with-sidebar-desktop-width)/ 2) - ($featured-browse-category-margin-desktop * 2);
+$with-sidebar-desktop-medium-image-width: 220px;
+
+// Tablet
+$featured-browse-category-margin-tablet: 20px;
+$no-sidebar-tablet-large-image-width: floor(($container-tablet)/ 3) - $featured-browse-category-margin-tablet;
+$with-sidebar-tablet-large-image-width: floor(($container-tablet)/ 2) - ($featured-browse-category-margin-tablet * 2);
+
+// Extra small
+$no-sidebar-xs-image-width: 190px;
+$with-sidebar-xs-image-width: $no-sidebar-xs-image-width;
+
+// Height adjustments
+$aspect-ratio-factor-large-image: 0.75; // 4:3 width:height
+$aspect-ratio-factor-medium-image: 1; // 1:1 width: height
 
 .browse-category {
   background-size: cover;
@@ -39,19 +62,30 @@ $with-sidebar-large-image-width: $no-sidebar-large-image-width;
 [data-sidebar="false"] {
   &.categories-1, &.categories-2, &.categories-3 {
     .browse-category {
-      height: $largest-featured-browse-category-height;
-      @media (max-width: $screen-md-max) {
-        width: $no-sidebar-medium-image-width;
+      width: $no-sidebar-xs-image-width;
+      height: $no-sidebar-xs-image-width * $aspect-ratio-factor-large-image;
+      @media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+        width: $no-sidebar-tablet-large-image-width;
+        height: $no-sidebar-tablet-large-image-width * $aspect-ratio-factor-large-image;
+      }
+      @media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+        width: $no-sidebar-desktop-large-image-width;
+        height: $no-sidebar-desktop-large-image-width * $aspect-ratio-factor-large-image;
       }
       @media (min-width: $screen-lg-min) {
-        width: $no-sidebar-large-image-width;
+        width: $no-sidebar-large-desktop-large-image-width;
+        height: $no-sidebar-large-desktop-large-image-width * $aspect-ratio-factor-large-image;
       }
     }
   }
   &.categories-4, &.categories-5 {
     .browse-category {
-      width: $smallest-featured-browse-category-width;
-      height: $smallest-featured-browse-category-height;
+      width: $no-sidebar-large-desktop-medium-image-width;
+      height: $no-sidebar-large-desktop-medium-image-width * $aspect-ratio-factor-medium-image;
+      @media (max-width: $screen-xs-max) {
+        width: $no-sidebar-xs-image-width;
+        height: $no-sidebar-xs-image-width * $aspect-ratio-factor-medium-image;
+      }
     }
     .category-4 {
       @extend .hidden-sm;
@@ -66,23 +100,35 @@ $with-sidebar-large-image-width: $no-sidebar-large-image-width;
 [data-sidebar="true"] {
   &.categories-1, &.categories-2 {
     .browse-category {
-      height: $largest-featured-browse-category-height;
-      @media (max-width: $screen-md-max) {
-        width: $with-sidebar-medium-image-width;
+      width: $with-sidebar-xs-image-width;
+      height: $with-sidebar-xs-image-width * $aspect-ratio-factor-large-image;
+      @media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+        width: $with-sidebar-tablet-large-image-width;
+        height: $with-sidebar-tablet-large-image-width * $aspect-ratio-factor-large-image;
+      }
+      @media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+        width: $with-sidebar-desktop-large-image-width;
+        height: $with-sidebar-desktop-large-image-width * $aspect-ratio-factor-large-image;
       }
       @media (min-width: $screen-lg-min) {
-        width: $with-sidebar-large-image-width;
+        width: $with-sidebar-large-desktop-large-image-width;
+        height: $with-sidebar-large-desktop-large-image-width * $aspect-ratio-factor-large-image;
       }
     }
   }
   &.categories-3, &.categories-4, &.categories-5 {
    .browse-category {
-      width: $smallest-featured-browse-category-width;
-      height: $smallest-featured-browse-category-height;
+    width: $with-sidebar-desktop-medium-image-width;
+    height: $with-sidebar-desktop-medium-image-width * $aspect-ratio-factor-medium-image;
+      @media (max-width: $screen-xs-max) {
+        width: $with-sidebar-xs-image-width;
+        height: $with-sidebar-xs-image-width * $aspect-ratio-factor-medium-image;
+      }
+      @media (min-width: $screen-lg-min) {
+        width: $with-sidebar-large-desktop-medium-image-width;
+        height: $with-sidebar-large-desktop-medium-image-width * $aspect-ratio-factor-medium-image;
+      }
     }
-  }
-  .category-3 {
-    @extend .hidden-sm;
   }
   .category-4, .category-5 {
     display: none;


### PR DESCRIPTION
Fixes #957 

Updates the SCSS to calculate the image width values based on the Bootstrap container size. In a couple of places I couldn't avoid a using fixed values without just throwing an arbitrary value into the width formula.

Calculates the image height values based on a ratio that applies at all container sizes.

Things still don't look ideal at less than tablet size, but I don't think it's worth the time right now to figure out how to improve the xs size. And it's not ideal that at the smaller widths the smaller images are just as wide as the "large" ones, but in practice I don't think it will be as noticeable as it is in the examples below because presumably curators won't normally put two instances of the widget right next to each other.

## No sidebar

![no-sidebar](https://cloud.githubusercontent.com/assets/101482/6312754/f6c3eb30-b939-11e4-834e-1481903192b9.gif)

## Sidebar

![sidebar](https://cloud.githubusercontent.com/assets/101482/6312755/ffb250e2-b939-11e4-8d47-88fcee5db6ee.gif)
