### PR TITLE
Revert "Use Spotlight::Engine.catalog_controller to provide the name of ...

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -1,4 +1,4 @@
-class Spotlight::CatalogController < Spotlight::Engine.catalog_controller
+class Spotlight::CatalogController < ::CatalogController
   include Spotlight::Concerns::ApplicationController
   load_and_authorize_resource :exhibit, class: Spotlight::Exhibit, prepend: true
   include Spotlight::Catalog


### PR DESCRIPTION
...the parent class for Spotlight::CatalogController"

This reverts commit 2ad43966b64aa7e893c71d680b973c863924794d.