### PR TITLE
Updates to item grid widget styling

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -299,7 +299,7 @@
 
   }
   @media (max-width: $screen-sm-max) {
-    .items-col {margin-bottom: 20px;}
+    .items-col {margin-bottom: $line-height-computed;}
   }
 }
 

--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -12,11 +12,11 @@
 }
 
 .primary-actions {
-  @extend .pull-right; 
+  @extend .pull-right;
 }
 
 #nested-pages {
-  margin-bottom: 1em;  
+  margin-bottom: 1em;
 }
 
 .st-title {
@@ -156,10 +156,10 @@
 }
 
 .st-block-ui-btn, .st-block-control-ui-btn {
-  
+
   color: $panel-info-text;
   border-color: $panel-info-heading-bg;
-  
+
   &:hover {
     color: $panel-info-text;
     border-color: $panel-info-heading-bg;
@@ -241,6 +241,7 @@
 }
 
 .item-grid-block {
+  h3 {margin-top: 0;}
   .items-col {
     display: flex;
     flex-flow: row wrap;
@@ -261,6 +262,7 @@
 
         a {
           & > img {
+            border: 1px solid $gray-light;
             width: 100%;
             height: 100%;
             object-fit: cover;
@@ -295,6 +297,9 @@
       }
     }
 
+  }
+  @media (max-width: $screen-sm-max) {
+    .items-col {margin-bottom: 20px;}
   }
 }
 


### PR DESCRIPTION
Closes #998 

* Remove top margin from heading
* Add 1px border to images
* At small viewport and smaller, when image grid and heading are stacked, add margin between them

#### Before
![before](https://cloud.githubusercontent.com/assets/101482/6493611/a904e940-c270-11e4-96a3-d412ecf8d4df.png)
----

#### After
![after](https://cloud.githubusercontent.com/assets/101482/6493592/9065848a-c270-11e4-87fa-85f4b2ef4fbe.png)
----

#### Small viewport
![small-viewport](https://cloud.githubusercontent.com/assets/101482/6493637/e32d128c-c270-11e4-96fe-d244adc66bc6.png)
