### PR TITLE
Add exhibit-style browse category landing page 

### DIFF
--- a/app/assets/stylesheets/spotlight/_browse.scss
+++ b/app/assets/stylesheets/spotlight/_browse.scss
@@ -13,7 +13,7 @@ $image-overlay-bottom-margin: $padding-large-vertical * 3;
 
 .long-description-text {
   column-width: 20em;
-  column-gap: 1em;
+  column-gap: 3em;
   margin: ($padding-base-vertical * 2) 0;
 }
 

--- a/app/assets/stylesheets/spotlight/_header.scss
+++ b/app/assets/stylesheets/spotlight/_header.scss
@@ -14,6 +14,23 @@ $masthead-image-blur: 1px;
   z-index: 1;
 }
 
+#exhibit-navbar {
+  &.search-masthead {
+    background-color: $gray;
+    margin-bottom: 0;
+    border: 0;
+    border-radius: 0;
+    .navbar-nav {
+      float: right;
+    }
+    .navbar-brand, .navbar-nav li {
+      color: $gray-lighter;
+      &.active a {color: $gray;}
+      a {color: $gray-lighter;}
+    }
+  }
+}
+
 .navbar + .navbar {
   margin-top: 0;
 }
@@ -35,6 +52,15 @@ $masthead-image-blur: 1px;
     -webkit-transform: translateY(-50%);
     transform: translateY(-50%);
   }
+  &.with-search-masthead {
+    margin-bottom: $padding-base-vertical;
+    .search-title {
+      text-align: center;
+      small {
+        text-transform: uppercase ;
+      }
+    }
+  }
   .site-title {
     font-size: 30px;
   }
@@ -45,7 +71,7 @@ $masthead-image-blur: 1px;
   }
 
   &.with-image {
-    .site-title {
+    .site-title, .search-title {
       color: $white;
       text-shadow: 0 1px 0 $black;
     }

--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -1,4 +1,5 @@
 module Spotlight::MainAppHelpers
+  include Spotlight::NavbarHelper
   def cache_key_for_spotlight_exhibits
     Spotlight::Exhibit.maximum(:updated_at).try(:utc).try(:to_s, :number)
   end

--- a/app/helpers/spotlight/navbar_helper.rb
+++ b/app/helpers/spotlight/navbar_helper.rb
@@ -1,0 +1,7 @@
+module Spotlight
+  module NavbarHelper
+    def should_render_spotlight_search_bar?
+      (!current_exhibit || current_exhibit.searchable?) && !current_search_masthead?
+    end
+  end
+end

--- a/app/jobs/spotlight/set_default_thumbnail_job.rb
+++ b/app/jobs/spotlight/set_default_thumbnail_job.rb
@@ -1,3 +1,5 @@
+# This is not currently used.
+# Leaving around as a proof-of-concept for future improvement.
 module Spotlight
   class SetDefaultThumbnailJob < ActiveJob::Base
     queue_as :default

--- a/app/views/shared/_exhibit_masthead.html.erb
+++ b/app/views/shared/_exhibit_masthead.html.erb
@@ -1,7 +1,7 @@
 <%= cache [current_exhibit,cache_key_for_spotlight_exhibits] do %>
-<div id="exhibit-masthead" class="jumbotron <%= 'with-image' if current_exhibit.masthead.try(:display?) %>">
-  <% if current_exhibit.masthead.try(:display?) %>
-    <span class='background-container' style="background-image: url('<%= current_exhibit.masthead.image.cropped %>')"></span>
+<div id="exhibit-masthead" class="<%= 'jumbotron' unless current_search_masthead? %><%= ' with-image' if current_masthead %><%= ' with-search-masthead' if current_search_masthead? %>">
+  <% if current_masthead %>
+    <span class='background-container' style="background-image: url('<%= image_path(current_masthead.image.cropped) %>')"></span>
     <span class='background-container-gradient'></span>
   <% end %>
   <div class="container">
@@ -20,9 +20,15 @@
       <% end %>
     </ul>
     <div class="site-title h1">
-      <%= current_exhibit.title %>
-      <% if current_exhibit.subtitle %>
-        <small><%= current_exhibit.subtitle %></small>
+      <% if current_search_masthead? %>
+        <div class='search-title'>
+          <%= render 'spotlight/browse/search_title' %>
+        </div>
+      <% else %>
+        <%= current_exhibit.title %>
+        <% if current_exhibit.subtitle %>
+          <small><%= current_exhibit.subtitle %></small>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -1,5 +1,8 @@
-<div id="exhibit-navbar" class="navbar navbar-default" role="navigation">
+<div id="exhibit-navbar" class="navbar navbar-default<%= ' search-masthead' if current_search_masthead? %>" role="navigation">
   <div class="container">
+    <% if current_search_masthead? %>
+      <%= link_to(current_exhibit.title, spotlight.exhibit_path(current_exhibit), class: 'navbar-brand') %>
+    <% end %>
     <ul class="nav navbar-nav">
       <% if current_exhibit %>
         <li class="<%= "active" if current_page?(current_exhibit) %>"><%= link_to t(:'spotlight.curation.nav.home'), current_exhibit %></li>
@@ -8,7 +11,7 @@
         <% end %>
       <% end %>
     </ul>
-    <% if !current_exhibit || current_exhibit.searchable? %>
+    <% if should_render_spotlight_search_bar? %>
       <div class="navbar-right col-sm-4 col-md-4">
         <%= render_search_bar  %>
       </div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -16,9 +16,12 @@
   </div>
 </div>
 
+<%= render 'shared/exhibit_navbar' if current_search_masthead? %>
 <% if current_exhibit %>
-<%= render 'spotlight/shared/report_a_problem' if show_contact_form? %>
-<%= render 'shared/exhibit_masthead' %>
+  <%= render 'spotlight/shared/report_a_problem' if show_contact_form? %>
+  <%= render 'shared/exhibit_masthead' %>
 <% end %>
-<%= render 'shared/exhibit_navbar' %>
-<%= render 'shared/breadcrumbs' %>
+<% unless current_search_masthead? %>
+  <%= render 'shared/exhibit_navbar' %>
+  <%= render 'shared/breadcrumbs' %>
+<% end %>

--- a/app/views/spotlight/browse/_search.html.erb
+++ b/app/views/spotlight/browse/_search.html.erb
@@ -6,7 +6,7 @@
         <div class="text-overlay">
            <h2 class="browse-category-title">
              <%= search.title%>
-             <small><%= pluralize(search.count, 'items') %></small>
+             <small><%= t :'spotlight.browse.search.item_count', count: search.count %></small>
            </h2>
          </div>
       </div>

--- a/app/views/spotlight/browse/_search_title.html.erb
+++ b/app/views/spotlight/browse/_search_title.html.erb
@@ -1,0 +1,2 @@
+<h1><%= @search.title %></h1>
+<small class="item-count"><%= t :'spotlight.browse.search.item_count', count: @search.count %></small>

--- a/app/views/spotlight/browse/show.html.erb
+++ b/app/views/spotlight/browse/show.html.erb
@@ -1,8 +1,9 @@
 <% set_html_page_title @search.title %>
 <div>
   <%= exhibit_edit_link @search, class: 'edit-button pull-right btn btn-primary' if can? :edit, @search %>
-  <h1><%= @search.title %></h1>
-  <small class="item-count"><%= t :'spotlight.browse.search.item_count', count: @search.count %></small>
+  <% unless current_search_masthead? %>
+    <%= render 'search_title' %>
+  <% end %>
   <% if @search.long_description.present? %>
     <p class="long-description-text"><%= @search.long_description %></p>
   <% end %>

--- a/lib/spotlight/controller.rb
+++ b/lib/spotlight/controller.rb
@@ -5,11 +5,19 @@ module Spotlight
     include Spotlight::Config
 
     included do
-      helper_method :current_exhibit
+      helper_method :current_exhibit, :current_masthead, :current_search_masthead?
     end
 
     def current_exhibit
       @exhibit
+    end
+
+    def current_masthead
+      [@search.try(:masthead), current_exhibit.try(:masthead)].compact.select(&:display?).first
+    end
+
+    def current_search_masthead?
+      @search && @search.masthead.try(:display?)
     end
 
     # overwrites Blacklight::Controller#blacklight_config

--- a/spec/helpers/spotlight/navbar_helper_spec.rb
+++ b/spec/helpers/spotlight/navbar_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+module Spotlight
+  describe NavbarHelper, :type => :helper do
+    describe '#should_render_search_bar?' do
+      before do
+        allow(helper).to receive_messages(current_exhibit: nil)
+        allow(helper).to receive_messages(current_search_masthead?: nil)
+      end
+      it 'should return true when there is no exhibit context' do
+        expect(helper.should_render_spotlight_search_bar?).to be_truthy
+      end
+      it 'should return true if searchable' do
+        allow(helper).to receive_messages(current_exhibit: double(searchable?: true))
+        expect(helper.should_render_spotlight_search_bar?).to be_truthy
+      end
+      it 'should return false if currently under an "Exhibity" browse category' do
+        allow(helper).to receive_messages(current_search_masthead?: true)
+        expect(helper.should_render_spotlight_search_bar?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/lib/spotlight/controller_spec.rb
+++ b/spec/lib/spotlight/controller_spec.rb
@@ -12,4 +12,56 @@ describe Spotlight::Controller do
       expect(subject.current_exhibit).to be_nil
     end
   end
+  describe '#current_search_masthead?' do
+    let(:masthead) { double('masthead', display?: true) }
+    let(:no_display_masthead) { double('no-display-masthead', display?: false) }
+    let(:search) { FactoryGirl.create(:search) }
+    it 'should be false by default' do
+      expect(subject.current_search_masthead?).to be_falsey
+    end
+    it "should return false if the current search's masthead is not set to display" do
+      allow(search).to receive_messages(masthead: no_display_masthead)
+      subject.instance_variable_set(:@search, search)
+      expect(subject.current_search_masthead?).to be_falsey
+    end
+    it "should return true if the current search's masthead is set to display" do
+      allow(search).to receive_messages(masthead: masthead)
+      subject.instance_variable_set(:@search, search)
+      expect(subject.current_search_masthead?).to be_truthy
+    end
+  end
+  describe '#current_masthead' do
+    let(:search_masthead) { double('search-masthead', display?: true) }
+    let(:no_display_search_masthead) { double('no-display-search-masthead', display?: false) }
+    let(:exhibit_masthead) { double('exhibit-masthead', display?: true) }
+    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    let(:search) { FactoryGirl.create(:search) }
+    it 'should be nil by default' do
+      expect(subject.current_masthead).to be_nil
+    end
+    it 'should return the search masthead if available' do
+      allow(search).to receive_messages(masthead: search_masthead)
+      subject.instance_variable_set(:@search, search)
+      expect(subject.current_masthead).to eq search_masthead
+    end
+    it 'should return the exhibit masthead if available' do
+      allow(exhibit).to receive_messages(masthead: exhibit_masthead)
+      subject.instance_variable_set(:@exhibit, exhibit)
+      expect(subject.current_masthead).to eq exhibit_masthead
+    end
+    it 'should return the search masthead if both the exhibit and search masthead are available' do
+      allow(search).to receive_messages(masthead: search_masthead)
+      subject.instance_variable_set(:@search, search)
+      allow(exhibit).to receive_messages(masthead: exhibit_masthead)
+      subject.instance_variable_set(:@exhibit, exhibit)
+      expect(subject.current_masthead).to eq search_masthead
+    end
+    it 'should return the exhibit masthead if the search masthead is set to not display' do
+      allow(search).to receive_messages(masthead: no_display_search_masthead)
+      subject.instance_variable_set(:@search, search)
+      allow(exhibit).to receive_messages(masthead: exhibit_masthead)
+      subject.instance_variable_set(:@exhibit, exhibit)
+      expect(subject.current_masthead).to eq exhibit_masthead
+    end
+  end
 end

--- a/spec/views/shared/_exhibit_masthead.html.erb_spec.rb
+++ b/spec/views/shared/_exhibit_masthead.html.erb_spec.rb
@@ -3,21 +3,68 @@ require 'spec_helper'
 module Spotlight
   describe "shared/_exhibit_masthead", :type => :view do
     let(:masthead) { Spotlight::Masthead.new }
+    let(:search) { double(title: "Search Title", count: '12') }
     let(:current_exhibit) { double(title: "Some title", subtitle: "Subtitle", masthead: masthead) }
+    let(:current_masthead) { double() }
     let(:current_exhibit_without_subtitle) { double(title: "Some title", subtitle: nil, masthead: masthead) }
-  
-    it "should display the title and subtitle" do
-      allow(view).to receive_messages(current_exhibit: current_exhibit)
-      render
-      expect(rendered).to have_selector('.site-title', text: "Some title")
-      expect(rendered).to have_selector('.site-title small', text: "Subtitle")
+    before do
+      allow(view).to receive_messages(current_search_masthead?: nil)
+      allow(view).to receive_messages(current_masthead: nil)
+      allow(current_masthead).to receive_message_chain(:image, :cropped).and_return('/uploads/image.jpg')
     end
 
-    it "should display just the title" do
-      allow(view).to receive_messages(current_exhibit: current_exhibit_without_subtitle)
-      render
-      expect(rendered).to have_selector('.site-title', text: "Some title")
-      expect(rendered).to_not have_selector('.site-title small')
+    describe 'title' do
+      it "should display the title and subtitle" do
+        allow(view).to receive_messages(current_exhibit: current_exhibit)
+        render
+        expect(rendered).to have_selector('.site-title', text: "Some title")
+        expect(rendered).to have_selector('.site-title small', text: "Subtitle")
+      end
+
+      it "should display just the title" do
+        allow(view).to receive_messages(current_exhibit: current_exhibit_without_subtitle)
+        render
+        expect(rendered).to have_selector('.site-title', text: "Some title")
+        expect(rendered).to_not have_selector('.site-title small')
+      end
     end
+
+    describe 'masthead from exhibit' do
+      before { allow(view).to receive_messages(current_exhibit: current_exhibit) }
+      it 'should not include the background element when there is no masthead' do
+        render
+        expect(rendered).to_not have_selector('.background-container')
+        expect(rendered).to_not have_selector('.background-container-gradient')
+      end
+      it 'should include the background image from the current exhibit' do
+        allow(view).to receive_messages(current_masthead: current_masthead)
+        render
+        expect(rendered).to have_selector('.background-container[style="background-image: url(\'/uploads/image.jpg\')"]')
+        expect(rendered).to have_selector('.background-container-gradient')
+      end
+    end
+
+    describe 'masthead from search' do
+      before do
+        allow(view).to receive_messages(current_exhibit: current_exhibit)
+        allow(view).to receive_messages(current_masthead: current_masthead)
+        allow(view).to receive_messages(current_search_masthead?: true)
+        assign(:search, search)
+        render
+      end
+      it 'should include the background image from the current search' do
+        expect(rendered).to have_selector('.background-container[style="background-image: url(\'/uploads/image.jpg\')"]')
+        expect(rendered).to have_selector('.background-container-gradient')
+      end
+      it 'should not include the exhibit title when there is a current search masthead' do
+        expect(rendered).to_not have_selector('.site-title', text: "Some title")
+        expect(rendered).to_not have_selector('.site-title small', text: "Subtitle")
+      end
+      it 'should include the search title and count when there is a current search masthead' do
+        expect(rendered).to have_selector('.site-title', text: "Search Title")
+        expect(rendered).to have_selector('.site-title small', text: "12 items")
+      end
+    end
+
   end
 end

--- a/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
@@ -9,10 +9,17 @@ module Spotlight
     let(:unpublished_about_page) { FactoryGirl.create(:about_page, published: false, exhibit: current_exhibit) }
 
     before :each do
+      allow(view).to receive_messages(current_search_masthead?: nil)
       allow(view).to receive_messages(current_exhibit: current_exhibit)
       allow(view).to receive_messages(on_browse_page?: false, on_about_page?: false)
       allow(view).to receive_messages(render_search_bar: "Search Bar")
       allow(view).to receive_messages(exhibit_path: spotlight.exhibit_path(current_exhibit))
+    end
+
+    it 'should link to the exhibit home page (as branding) when there is a current search masthead' do
+      allow(view).to receive_messages(current_search_masthead?: true)
+      render
+      expect(response).to have_selector("a.navbar-brand", text: current_exhibit.title)
     end
 
     it "should link to the search page if no home page is defined" do
@@ -108,6 +115,12 @@ module Spotlight
 
     it 'should not include the search bar when the exhibit is searchable' do
       expect(current_exhibit).to receive(:searchable?).and_return(false)
+      render
+      expect(response).to_not have_content "Search Bar"
+    end
+
+    it 'should not include the search bar when there is a current search masthead' do
+      allow(view).to receive_messages(current_search_masthead?: true)
       render
       expect(response).to_not have_content "Search Bar"
     end

--- a/spec/views/shared/_header_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_header_navbar.html.erb_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+module Spotlight
+  describe "shared/_header_navbar", :type => :view do
+    let(:current_exhibit) { FactoryGirl.create(:exhibit) }
+    let(:masthead) { 'exhibit-masthead' }
+    let(:navbar) { 'exhibit-navbar' }
+    let(:breadcrumbs) { 'exhibit-breadcrumbs' }
+    before do
+      stub_template '_user_util_links.html.erb' => 'links'
+      stub_template 'shared/_exhibit_masthead.html.erb' => masthead
+      stub_template 'shared/_exhibit_navbar.html.erb' => navbar
+      stub_template 'shared/_breadcrumbs.html.erb' => breadcrumbs
+      allow(view).to receive_messages(current_search_masthead?: nil)
+      allow(view).to receive_messages(current_exhibit: current_exhibit)
+    end
+    it 'should render the masthead above the navbar' do
+      render
+      expect(rendered.index(masthead)).to be < rendered.index(navbar)
+    end
+    it 'should render the navbar above the search masthead' do
+      allow(view).to receive_messages(current_search_masthead?: true)
+      render
+      expect(rendered.index(navbar)).to be < rendered.index(masthead)
+    end
+    it 'should render the breadcrumbs' do
+      render
+      expect(rendered).to have_content(breadcrumbs)
+    end
+    it 'should not render breadcrumbs when there is a search masthead' do
+      allow(view).to receive_messages(current_search_masthead?: true)
+      render
+      expect(rendered).to_not have_content(breadcrumbs)
+    end
+  end
+end

--- a/spec/views/spotlight/browse/show.html.erb_spec.rb
+++ b/spec/views/spotlight/browse/show.html.erb_spec.rb
@@ -5,6 +5,7 @@ describe 'spotlight/browse/show', :type => :view do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
 
   before :each do
+    allow(view).to receive_messages(current_search_masthead?: nil)
     allow(view).to receive_messages(blacklight_config: Blacklight::Configuration.new )
     view.blacklight_config.view.gallery = true
     allow(search).to receive_messages(count: 15)
@@ -19,20 +20,23 @@ describe 'spotlight/browse/show', :type => :view do
     assign :document_list, []
   end
 
-  it "should have a heading" do
+  it "should have a heading and item count when there is no current search masthead" do
     render
     expect(response).to have_selector 'h1', text: search.title
+    expect(response).to have_selector ".item-count", text: "#{search.count} items"
+  end
+
+  it 'should not have the heading and item count when there is a current search masthead' do
+    allow(view).to receive_messages(current_search_masthead?: true)
+    render
+    expect(response).to_not have_selector 'h1', text: search.title
+    expect(response).to_not have_selector ".item-count", text: "#{search.count} items"
   end
 
   it "should have an edit button" do
     allow(view).to receive_messages(can?: true)
     render
     expect(response).to have_selector '.btn', text: 'Edit'
-  end
-
-  it "should display the item count" do
-    render
-    expect(response).to have_selector ".item-count", text: "#{search.count} items"
   end
 
   it "should display the long description" do


### PR DESCRIPTION
Closes #919 

### Browse Landing Page
![browse-landing](https://cloud.githubusercontent.com/assets/96776/6535222/1a7599b6-c3f8-11e4-8891-dfb290301d41.png)

### Search With Masthead
![search-masthead](https://cloud.githubusercontent.com/assets/96776/6535223/1a779fae-c3f8-11e4-94e4-6f7a3b9ba94a.png)

### Search Without Masthead
![exhibit-masthead](https://cloud.githubusercontent.com/assets/96776/6535224/1a783478-c3f8-11e4-8249-ea89e5dc7569.png)