### PR TITLE
Use jcrop's animated loading icon when images are loading.

### DIFF
--- a/app/assets/javascripts/spotlight/croppable.js
+++ b/app/assets/javascripts/spotlight/croppable.js
@@ -49,6 +49,11 @@ Spotlight.onLoad(function() {
       };
 
       if(!cropbox.data('jcropProcessed')){
+        // Hack to get cropbox image element to be loaded under turbolinks
+        if (cropbox[0].complete === false && cropbox[0].src == window.location.href) {
+           // add 1x1 gif to to img tag so it's loaded
+          cropbox[0].src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+        }
         cropbox.Jcrop(
           $.extend(options, {
             onSelect: update,

--- a/app/assets/javascripts/spotlight/croppable.js
+++ b/app/assets/javascripts/spotlight/croppable.js
@@ -23,6 +23,7 @@ Spotlight.onLoad(function() {
       var cropinfo = $("#" + cropid + "_crop").val();
       var cropbox = $("#" + cropid + "_cropbox");
       var previewbox = $("#" + cropid + "_previewbox");
+      var jcropLoadingArea = cropbox.closest('.croppable-loading-area');
 
       var defaults = {
         setSelect: $.parseJSON(cropinfo || pluginDefults['setSelect']),
@@ -63,7 +64,12 @@ Spotlight.onLoad(function() {
       }
       cropbox.data('jcropProcessed', 'true');
 
+      cropbox.on('load', function(){
+        jcropLoadingArea.removeClass("loading-jcrop");
+      });
+
       fileUpload.on('change', function() {
+        jcropLoadingArea.addClass("loading-jcrop");
         var jcrop_api = cropbox.data('Jcrop');
         if(this.files){
           var file = this.files[0];

--- a/app/assets/stylesheets/spotlight/_croppable.scss
+++ b/app/assets/stylesheets/spotlight/_croppable.scss
@@ -1,0 +1,15 @@
+@mixin jcrop-loading-background {
+  background-image: url('/assets/Jcrop.gif');
+  background-color: transparent !important;
+}
+.croppable-loading-area {
+  min-height: 100px;
+}
+
+.loading-jcrop {
+  @include jcrop-loading-background;
+  .jcrop-tracker {
+    @include jcrop-loading-background;
+  }
+}
+

--- a/app/assets/stylesheets/spotlight/_spotlight.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.scss
@@ -10,6 +10,7 @@
 @import "spotlight/header";
 @import "spotlight/footer";
 @import "spotlight/catalog";
+@import "spotlight/croppable";
 @import "spotlight/curation";
 @import "spotlight/exhibit_admin";
 @import "spotlight/edit_in_place";

--- a/app/assets/stylesheets/spotlight/typeahead.css
+++ b/app/assets/stylesheets/spotlight/typeahead.css
@@ -20,6 +20,7 @@
 }
 
 .tt-dropdown-menu {
+  z-index: 1000 !important;
   margin-top: 2px;
   padding: 8px 0;
   background-color: #fff;

--- a/app/views/spotlight/contacts/_form.html.erb
+++ b/app/views/spotlight/contacts/_form.html.erb
@@ -8,7 +8,7 @@
 
   <%= f.file_field :avatar, data: { croppable: true, aspect_ratio: 1, box_width: 600 } %>
 
-  <div class="form-group <%= "missing-croppable" unless @contact.avatar.present? %>">
+  <div class="form-group croppable-loading-area <%= "missing-croppable" unless @contact.avatar.present? %>">
     <div class="col-sm-5 col-sm-offset-2">
       <%= hidden_field_tag :contact_avatar_crop, ([@contact.avatar_crop_x.to_i, @contact.avatar_crop_y.to_i, @contact.avatar_crop_x.to_i + @contact.avatar_crop_w.to_i, @contact.avatar_crop_y.to_i + @contact.avatar_crop_h.to_i].to_json if @contact.avatar_crop_x) %>
       <%= f.previewbox :avatar %>

--- a/app/views/spotlight/featured_images/_form.html.erb
+++ b/app/views/spotlight/featured_images/_form.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 <%= field_set_tag(t(:'.source.remote.header')) do %>
   <p class="instructions"><%= t(:'.source.remote.help') %></p>
-  <div class="form-group  <%= "missing-croppable" unless f.object.try(:image).present? %>">
+  <div class="form-group croppable-loading-area <%= "missing-croppable" unless f.object.try(:image).present? %>">
     <%= hidden_field_tag :"#{jcrop_options.fetch(:selector, "image")}_crop", ([f.object.image_crop_x.to_i, f.object.image_crop_y.to_i, f.object.image_crop_x.to_i + f.object.image_crop_w.to_i, f.object.image_crop_y.to_i + f.object.image_crop_h.to_i].to_json if f.object.try(:image_crop_x)) %>
     <%= f.cropbox :image %>
   </div>


### PR DESCRIPTION
Closes #978 (sort-of, I don't think this takes care of all the cases we would want, but it's certainly a start)

![jcrop-loading](https://cloud.githubusercontent.com/assets/96776/6540682/c16819c0-c460-11e4-9fa0-264368271c66.gif)
