### PR TITLE
Remove extra labels on page options tab.

### DIFF
--- a/app/views/spotlight/about_pages/_page_options.html.erb
+++ b/app/views/spotlight/about_pages/_page_options.html.erb
@@ -1,1 +1,1 @@
-<%= f.check_box :published %> <%= f.label :published, t(:'.published') %>
+<%= f.check_box :published %>

--- a/app/views/spotlight/feature_pages/_page_options.html.erb
+++ b/app/views/spotlight/feature_pages/_page_options.html.erb
@@ -1,6 +1,6 @@
 <div>
-  <%= f.check_box :published %> <%= f.label :published, t(:'.published') %>
+  <%= f.check_box :published %>
 </div>
 <div>
-  <%= f.check_box :display_sidebar?, disabled: @page.child_pages.published.present? %> <%= f.label :display_sidebar?, t(:'spotlight.administration.show_sidebar') %>
+  <%= f.check_box :display_sidebar?, disabled: @page.child_pages.published.present? %>
 </div>

--- a/app/views/spotlight/home_pages/_page_options.html.erb
+++ b/app/views/spotlight/home_pages/_page_options.html.erb
@@ -1,2 +1,2 @@
-  <%= f.check_box :display_title %>
-  <%= f.check_box :display_sidebar?, disabled: !current_exhibit.searchable? %>
+<%= f.check_box :display_title %>
+<%= f.check_box :display_sidebar?, disabled: !current_exhibit.searchable? %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -351,7 +351,7 @@ en:
         instructions: Enter details for each librarian, curator or other contact person for this exhibit. Select the contacts you want to be show in the sidebar of the About Pages. Drag and drop contacts to specify the order in which they are shown in the sidebar.
       nav_link: About
       page_options:
-        published: "Publish"
+        published: "Publish" # Possibly no longer used
       sidebar:
         nav_link: About
       contacts:


### PR DESCRIPTION
Now that we're using bootstrap form on the page edit form we get labels generate for us (which are reasonable enough on their own).

#### Before
![before](https://cloud.githubusercontent.com/assets/96776/6561776/05edf2da-c651-11e4-82ae-109359846c98.png)

#### After
![after](https://cloud.githubusercontent.com/assets/96776/6561775/05eb2096-c651-11e4-8ff7-6c154a84e9e8.png)
