### PR TITLE
Update styling of appearance and browse edit pages

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
@@ -63,3 +63,19 @@ label.radio {
 #main-container .nav {
   margin-bottom: $line-height-computed;
 }
+
+.tab-pane {
+  > p.instructions:first-child, > fieldset:first-child {
+    margin-top: -$padding-base-vertical;
+  }
+  fieldset {
+    margin-bottom: $padding-large-vertical * 3;
+    margin-top: $padding-large-vertical * 2;
+  }
+  legend {
+    margin-bottom: $padding-large-vertical;
+  }
+  div.radio + div input, div.radio + input[type="file"] {
+    margin-top: $padding-large-vertical;
+  }
+}

--- a/app/assets/stylesheets/spotlight/_croppable.scss
+++ b/app/assets/stylesheets/spotlight/_croppable.scss
@@ -2,8 +2,9 @@
   background-image: url('/assets/Jcrop.gif');
   background-color: transparent !important;
 }
-.croppable-loading-area {
+.form-group.croppable-loading-area {
   min-height: 100px;
+  margin: ($padding-large-vertical * 2) $padding-large-vertical;
 }
 
 .loading-jcrop {

--- a/app/assets/stylesheets/spotlight/_curation.scss
+++ b/app/assets/stylesheets/spotlight/_curation.scss
@@ -149,22 +149,6 @@ h1,h2,h3,h4,h5,h6 {
   }
 }
 
-.tab-pane {
-  > p.instructions:first-child, > fieldset:first-child {
-    margin-top: -$padding-base-vertical;
-  }
-  fieldset {
-    margin-bottom: $padding-large-vertical * 3;
-    margin-top: $padding-large-vertical * 2;
-  }
-  legend {
-    margin-bottom: $padding-large-vertical;
-  }
-  div.radio + div input, div.radio + input[type="file"] {
-    margin-top: $padding-large-vertical;
-  }
-}
-
 .label.curation-widget {
   display: inline-block;
   margin-top: 1em;

--- a/app/assets/stylesheets/spotlight/_curation.scss
+++ b/app/assets/stylesheets/spotlight/_curation.scss
@@ -149,6 +149,22 @@ h1,h2,h3,h4,h5,h6 {
   }
 }
 
+.tab-pane {
+  > p.instructions:first-child, > fieldset:first-child {
+    margin-top: -$padding-base-vertical;
+  }
+  fieldset {
+    margin-bottom: $padding-large-vertical * 3;
+    margin-top: $padding-large-vertical * 2;
+  }
+  legend {
+    margin-bottom: $padding-large-vertical;
+  }
+  div.radio + div input, div.radio + input[type="file"] {
+    margin-top: $padding-large-vertical;
+  }
+}
+
 .label.curation-widget {
   display: inline-block;
   margin-top: 1em;

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -15,7 +15,7 @@
       <li role="presentation" class="active">
         <a href="#search-description" aria-controls="search-description" role="tab" data-toggle="tab"><%= t(:'.search_description') %></a>
       </li>
-      
+
       <li role="presentation">
         <a href="#search-masthead" aria-controls="search-masthead" role="tab" data-toggle="tab"><%= t(:'.search_masthead') %></a>
       </li>
@@ -25,7 +25,7 @@
       </li>
     </ul>
 
-    
+
     <div class="tab-content">
       <div role="tabpanel" class="tab-pane active" id="search-description">
         <%= f.text_field :title, control_col: "col-sm-5" %>
@@ -36,13 +36,14 @@
           </div>
         <% end unless @search.query_params.blank? %>
       </div>
-      <div role="tabpanel" class="tab-pane" id="search-masthead">  
+      <div role="tabpanel" class="tab-pane" id="search-masthead">
         <%= f.fields_for :masthead, (@search.masthead || @search.build_masthead) do |m| %>
           <p class="instructions"><%= t(:'.masthead.help') %></p>
+          <p class="instructions"><%= t(:'.masthead.help_secondary') %></p>
           <%= render '/spotlight/featured_images/form', f: m, jcrop_options: default_masthead_jcrop_options %>
         <% end %>
       </div>
-      <div role="tabpanel" class="tab-pane" id="search-thumbnail">  
+      <div role="tabpanel" class="tab-pane" id="search-thumbnail">
         <%= f.fields_for :thumbnail, (@search.thumbnail || @search.build_thumbnail) do |m| %>
           <p class="instructions"><%= t(:'.thumbnail.help') %></p>
           <%= render '/spotlight/featured_images/form', f: m, jcrop_options: default_thumbnail_jcrop_options %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -436,7 +436,8 @@ en:
         search_masthead: "Masthead"
         search_thumbnail: "Thumbnail"
         masthead:
-          help: "You can select and crop an image to use as a background in your exhibit site's masthead. To use an image as a masthead background, you should use an image that is at least 120 pixels tall and 1200 pixels wide. For best results use an image at least 1800 pixels wide. You can crop larger images using the cropping tool below."
+          help: "You can select and crop an image to use as a browse category-specific masthead, instead of the default site masthead, for this browse category's detail page."
+          help_secondary: "To create a browse category-specific masthead, you should use an image that is at least 120 pixels tall and 1200 pixels wide. For best results use an image at least 1800 pixels wide. You can crop larger images using the cropping tool below."
         thumbnail:
           help: "You can select and crop an image to visually represent this search."
     browse:


### PR DESCRIPTION
Close #1017 

- Improve formatting of edit pages
- Update instruction text for browse category edit, masthead tab

![curation_-_curation_-_browse___maps_of_africa__an_online_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/6564578/2939a11a-c667-11e4-8ca9-449c3f7dfc9d.png)
