### PR TITLE
Fix data attribute that hold autocomplete url on search edit form.

### DIFF
--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -1,4 +1,4 @@
-<%= bootstrap_form_for [@search.exhibit, @search], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-7', data: {:'autocomplete-url'=> spotlight.autocomplete_exhibit_search_path(@search.exhibit, @search, format: "json")}, html: {id: 'edit-search'} do |f| %>
+<%= bootstrap_form_for [@search.exhibit, @search], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-7', data: {autocomplete_exhibit_catalog_index_path: spotlight.autocomplete_exhibit_search_path(@search.exhibit, @search, format: "json")}, html: {id: 'edit-search'} do |f| %>
   <% if @search.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@search.errors.count, "error") %> prohibited this page from being saved:</h2>

--- a/spec/views/spotlight/searches/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/edit.html.erb_spec.rb
@@ -21,6 +21,11 @@ describe "spotlight/searches/edit.html.erb", :type => :view do
     allow(view).to receive_messages(default_masthead_jcrop_options: {}, default_thumbnail_jcrop_options: {})
   end
 
+  it 'renders a form w/ the appropriate autocomplete data attribute' do
+    render
+    expect(rendered).to have_selector 'form[data-autocomplete-exhibit-catalog-index-path]'
+  end
+
   it "renders active search constraints" do
     render
     expect(rendered).to have_selector '.appliedFilter .constraint-value'


### PR DESCRIPTION
Item autocomplete does not work for masthead or thumbnail currently.