### PR TITLE
Scale up masthead images to fill full width

### DIFF
--- a/app/assets/stylesheets/spotlight/_header.scss
+++ b/app/assets/stylesheets/spotlight/_header.scss
@@ -123,6 +123,7 @@ $masthead-image-blur: 1px;
   .background-container {
     @include masthead-background-containers();
     background-repeat: no-repeat;
+    background-size: cover;
     // Add small amount of blur to help text stand out
     //filter: url(masthead/blur.svg#blur); // for older versions of FF
     -webkit-filter: blur($masthead-image-blur);


### PR DESCRIPTION
e.g., when the browser window is way bigger than 1800px wide:

![screen shot 2015-03-12 at 1 43 20 pm](https://cloud.githubusercontent.com/assets/111218/6627779/e8e17b20-c8bd-11e4-9ad7-c7f2898525b5.png)

When the window is smaller than the image, the previous behavior still applies.