### PR TITLE
Update widget config panels

### DIFF
--- a/app/assets/javascripts/spotlight/block_mixins/autocompleteable.js
+++ b/app/assets/javascripts/spotlight/block_mixins/autocompleteable.js
@@ -5,22 +5,22 @@
 
     initializeAutocompleteable: function() {
       this.on("onRender", this.addAutocompletetoSirTrevorForm);
-      
+
       if (_.isUndefined(this['autocomplete_url'])) {
         this.autocomplete_url = function() { return $('form[data-autocomplete-url]').data('autocomplete-url').replace("%25QUERY", "%QUERY"); };
       }
-      
+
       if (_.isUndefined(this['autocomplete_template'])) {
         this.autocomplete_url = function() { return '<div class="autocomplete-item{{#if private}} blacklight-private{{/if}}">{{#if thumbnail}}<div class="document-thumbnail thumbnail"><img src="{{thumbnail}}" /></div>{{/if}}<span class="autocomplete-title">{{title}}</span><br/><small>&nbsp;&nbsp;{{description}}</small></div>' };
       }
-      
+
       if (_.isUndefined(this['transform_autocomplete_results'])) {
         this.transform_autocomplete_results = _.identity;
       }
     },
-    
+
     autocomplete_control: function() {
-      return '<input type="text" class="st-input-string form-control item-input-field" data-twitter-typeahead="true"/>';
+      return '<input type="text" class="st-input-string form-control item-input-field" data-twitter-typeahead="true" placeholder="Enter a title..."/>';
     },
 
     addAutocompletetoSirTrevorForm: function() {
@@ -46,7 +46,7 @@
       var block = this;
       var results = new Bloodhound({
         datumTokenizer: function(d) {
-          return Bloodhound.tokenizers.whitespace(d.title); 
+          return Bloodhound.tokenizers.whitespace(d.title);
         },
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         limit: 10,
@@ -59,7 +59,7 @@
       return results;
     },
   },
-  
+
 
   SirTrevor.Block.prototype.availableMixins.push("autocompleteable");
 })(jQuery);

--- a/app/assets/javascripts/spotlight/blocks/browse_block.js
+++ b/app/assets/javascripts/spotlight/blocks/browse_block.js
@@ -5,21 +5,21 @@ SirTrevor.Blocks.Browse = (function(){
   return Spotlight.Block.Resources.extend({
     type: "browse",
 
-    title: function() { return "Highlight Browse Categories"; },
+    title: function() { return "Browse Categories"; },
 
     icon_name: "pages",
     blockGroup: 'Exhibit item widgets',
-    description: "This widget displays browse  categories",
+    description: "This widget highlights browse categories. Each highlighted category links to the corresponding browse category results page.",
 
     autocomplete_url: function() { return this.$el.closest('form[data-autocomplete-exhibit-searches-path]').data('autocomplete-exhibit-searches-path').replace("%25QUERY", "%QUERY"); },
     autocomplete_template: function() { return '<div class="autocomplete-item{{#unless published}} blacklight-private{{/unless}}">{{#if thumbnail_image_url}}<div class="document-thumbnail thumbnail"><img src="{{thumbnail_image_url}}" /></div>{{/if}}<span class="autocomplete-title">{{title}}</span><br/><small>&nbsp;&nbsp;{{description}}</small></div>' },
 
-    item_options: function() { return [  
+    item_options: function() { return [
       '<label>',
         '<input type="checkbox" name="display-item-counts" value="true" checked />',
         'Include item counts?',
       '</label>'
-    ].join("\n") }, 
+    ].join("\n") },
   });
 
 })();

--- a/app/assets/javascripts/spotlight/blocks/pages_block.js
+++ b/app/assets/javascripts/spotlight/blocks/pages_block.js
@@ -5,11 +5,11 @@ SirTrevor.Blocks.FeaturedPages = (function(){
   return Spotlight.Block.Resources.extend({
     type: "featured_pages",
 
-    title: function() { return "Highlight Feature Pages"; },
+    title: function() { return "Feature Pages"; },
 
     icon_name: "pages",
     blockGroup: 'Exhibit item widgets',
-    description: "This widget displays pages",
+    description: "This widget highlights feature pages. Each highlighted item links to the corresponding feature page.",
 
     autocomplete_url: function() { return this.$el.closest('form[data-autocomplete-exhibit-feature-pages-path]').data('autocomplete-exhibit-feature-pages-path').replace("%25QUERY", "%QUERY"); },
     autocomplete_template: function() { return '<div class="autocomplete-item{{#unless published}} blacklight-private{{/unless}}">{{log "Look at me"}}{{log thumbnail_image_url}}{{#if thumbnail_image_url}}<div class="document-thumbnail thumbnail"><img src="{{thumbnail_image_url}}" /></div>{{/if}}<span class="autocomplete-title">{{title}}</span><br/><small>&nbsp;&nbsp;{{description}}</small></div>' },

--- a/app/assets/javascripts/spotlight/blocks/search_result_block.js
+++ b/app/assets/javascripts/spotlight/blocks/search_result_block.js
@@ -3,7 +3,7 @@
 SirTrevor.Blocks.SearchResults =  (function(){
 
   return SirTrevor.Blocks.Browse.extend({
-      
+
     type: "search_results",
 
     title: function() { return "Search Results"; },
@@ -13,17 +13,17 @@ SirTrevor.Blocks.SearchResults =  (function(){
     searches_key: "slug",
     view_key: "view",
     textable: false,
-    
+
     content: function() {
       return _.template([this.items_selector()].join("<hr />\n"))(this);
     },
-    
+
     description: "This widget displays a set of search results on a page. Specify a search result set by selecting an existing browse category. You can also select the view types that are available to the user when viewing the result set.",
-    
+
     item_options: function() {
       var block = this;
       var fields = $('[data-blacklight-configuration-search-views]').data('blacklight-configuration-search-views');
-    
+
       return $.map(fields, function(field) {
         checkbox = ""
         checkbox += "<div>";
@@ -35,11 +35,11 @@ SirTrevor.Blocks.SearchResults =  (function(){
         return checkbox;
       }).join("\n");
     },
-    
+
     afterPanelRender: function(data, panel) {
       this.$el.find('.item-input-field').attr("disabled", "disabled");
     },
-    
+
     afterPanelDelete: function() {
       this.$el.find('.item-input-field').removeAttr("disabled");
     },

--- a/app/assets/javascripts/spotlight/blocks/solr_documents_block.js
+++ b/app/assets/javascripts/spotlight/blocks/solr_documents_block.js
@@ -4,12 +4,12 @@ SirTrevor.Blocks.SolrDocuments = (function(){
 
   return Spotlight.Block.Resources.extend({
     type: "solr_documents",
-    title: function() { return "Items"; },
+    title: function() { return "Item Row"; },
     textable: true,
 
     icon_name: "items",
     blockGroup: 'Exhibit item widgets',
-    description: "This widget displays thumbnail images of repository items in a single row grid. Optionally, you can a caption below each image..",
+    description: "This widget displays exhibit items in a horizontal row. Optionally, you can add a heading and/or text to be displayed adjacent to the items.",
 
     autocomplete_url: function() { return this.$instance().closest('form[data-autocomplete-exhibit-catalog-index-path]').data('autocomplete-exhibit-catalog-index-path').replace("%25QUERY", "%QUERY"); },
     autocomplete_template: function() { return '<div class="autocomplete-item{{#if private}} blacklight-private{{/if}}">{{#if thumbnail}}<div class="document-thumbnail thumbnail"><img src="{{thumbnail}}" /></div>{{/if}}<span class="autocomplete-title">{{title}}</span><br/><small>&nbsp;&nbsp;{{description}}</small></div>' },
@@ -29,8 +29,8 @@ SirTrevor.Blocks.SolrDocuments = (function(){
     },
 
     item_options: function() { return this.caption_options(); },
-    
-    caption_options: function() { return [  
+
+    caption_options: function() { return [
       '<div class="field-select primary-caption" data-behavior="item-caption-admin">',
         '<input name="<%= show_primary_field_key %>" type="hidden" value="false" />',
         '<input data-input-select-target="#<%= formId(primary_field_key) %>" name="<%= show_primary_field_key %>" id="<%= formId(show_primary_field_key) %>" type="checkbox" value="true" />',
@@ -49,7 +49,7 @@ SirTrevor.Blocks.SolrDocuments = (function(){
           '<%= caption_option_values() %>',
         '</select>',
       '</div>',
-    ].join("\n") }, 
+    ].join("\n") },
 
     afterPanelRender: function(data, panel) {
       var context = this;

--- a/app/assets/javascripts/spotlight/blocks/solr_documents_carousel_block.js
+++ b/app/assets/javascripts/spotlight/blocks/solr_documents_carousel_block.js
@@ -9,14 +9,14 @@ SirTrevor.Blocks.SolrDocumentsCarousel = (function(){
 
     icon_name: "item_carousel",
     blockGroup: 'Exhibit item widgets',
-    description: "This widget displays thumbnail images of repository items in a carousel. You can configure the captions that appear below each carousel image and how the images are cycled.",
-    
+    description: "This widget displays exhibit items in a carousel. You can configure the item captions, how the images are cycled, and the size of the carousel.",
+
     auto_play_images_key: "auto-play-images",
     auto_play_images_interval_key: "auto-play-images-interval",
     max_height_key: "max-height",
 
     item_options: function() { return "" },
-    
+
     carouselCycleTimesInSeconds: {
       values: [ 3, 5, 8, 12, 20 ],
       selected: 5
@@ -44,7 +44,7 @@ SirTrevor.Blocks.SolrDocumentsCarousel = (function(){
         '</div>',
       ].join("\n");
     },
-    
+
     addCarouselCycleOptions: function(options) {
       var html = '';
 

--- a/app/assets/javascripts/spotlight/blocks/solr_documents_features_block.js
+++ b/app/assets/javascripts/spotlight/blocks/solr_documents_features_block.js
@@ -5,12 +5,12 @@ SirTrevor.Blocks.SolrDocumentsFeatures = (function(){
   return SirTrevor.Blocks.SolrDocuments.extend({
     textable: false,
     type: "solr_documents_features",
-    title: function() { return "Item Features"; },
+    title: function() { return "Item Slideshow"; },
 
     icon_name: "item_features",
     blockGroup: 'Exhibit item widgets',
-    description: "This widget displays items in features",
-    
+    description: "This widget displays exhibit items in a static slideshow. The user will move between items in the slideshow using the field you select as the primary caption.",
+
     afterPreviewLoad: function(options) {
       this.$el.find('.carousel').carousel();
 

--- a/app/assets/javascripts/spotlight/blocks/solr_documents_grid_block.js
+++ b/app/assets/javascripts/spotlight/blocks/solr_documents_grid_block.js
@@ -8,7 +8,7 @@ SirTrevor.Blocks.SolrDocumentsGrid = (function(){
 
     icon_name: "item_grid",
     blockGroup: 'Exhibit item widgets',
-    description: "This widget displays items in grids",
+    description: "This widget displays exhibit items in a multi-row grid. Optionally, you can add a heading and/or text to be displayed adjacent to the items.",
 
     item_options: function() { return "" }
   });

--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -23,18 +23,29 @@
   position: absolute;
   top: 0;
   left: 0;
-  display: none;
   background-color: $panel-info-heading-bg;
   padding: 3px 8px;
   color: $panel-info-text;
   font-weight: bold;
 }
 
-.st-block__inner:hover {
-  .st-title {
-    display: block;
+.st-block__inner {
+  div.field + div.field {
+    margin-top: 2 * $padding-large-vertical;
+  }
+
+  .field-select {
+    margin-bottom: $padding-large-vertical;
+    @media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+      margin-bottom: 2 * $padding-large-vertical;
+
+      > select {
+        margin-left: 2 * $padding-small-horizontal;
+      }
+    }
   }
 }
+
 #sidebar {
   li {
     margin-top: $padding-small-vertical;

--- a/app/assets/stylesheets/spotlight/_sir-trevor_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_sir-trevor_overrides.scss
@@ -2,7 +2,7 @@
 
 .widget-header {
   padding: 5px;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
   border-bottom: 1px solid #D4D4D4;
 }
 
@@ -78,9 +78,11 @@
 .st-block__inner {
   @extend .panel;
   @extend .panel-default;
-  
+
   border-color: $gray-lighter;
   box-shadow: 3px 3px 15px $gray-lighter;
+
+  padding-top: 2.5em;
 
   &:hover {
     @extend .panel-info;
@@ -121,4 +123,12 @@
 
 .st-icon--add:after {
   cursor: pointer;
+}
+
+.st-title {
+  display: block;
+}
+
+.st-block-positioner {
+  left: -6.5em;
 }

--- a/spec/features/javascript/blocks/solr_documents_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_block_spec.rb
@@ -11,14 +11,14 @@ feature "Solr Document Block", feature: true do
     )
   end
 
-  before do 
+  before do
     login_as exhibit_curator
     visit spotlight.edit_exhibit_feature_page_path(exhibit, feature_page)
     add_widget 'solr_documents'
   end
 
   scenario "it should allow you to add the solr document block widget", js: true do
-    expect(page).to have_content "This widget displays thumbnail images of repository items in a single row grid."
+    expect(page).to have_content "This widget displays exhibit items in a horizontal row. Optionally, you can add a heading and/or text to be displayed adjacent to the items."
     expect(page).to have_content "Primary caption"
     expect(page).to have_content "Secondary caption"
     expect(page).to have_content "Display text on"
@@ -41,7 +41,7 @@ feature "Solr Document Block", feature: true do
       expect(page).not_to have_css(".title")
     end
   end
-  
+
   scenario "it should allow you to add multiple solr documents to the widget", js: true do
     fill_in_typeahead_field with: "dq287tq6352"
     fill_in_typeahead_field with: "gk446cj2442"
@@ -50,16 +50,16 @@ feature "Solr Document Block", feature: true do
 
     expect(page).to have_selector ".items-block .box", count: 2
   end
-  
+
   scenario "it should allow you toggle visibility of solr documents", js: true do
     fill_in_typeahead_field with: "dq287tq6352"
-  
+
     within(:css, '.panel') do
       uncheck "Display?"
     end
 
     fill_in_typeahead_field with: "gk446cj2442"
-    
+
     # display the title as the primary caption
     within('.primary-caption') do
       check("Primary caption")
@@ -73,7 +73,7 @@ feature "Solr Document Block", feature: true do
     expect(page).not_to have_content "L'AMERIQUE"
   end
 
-  scenario "should allow you to optionally display captions with the image", js: true do    
+  scenario "should allow you to optionally display captions with the image", js: true do
     fill_in_typeahead_field with: "gk446cj2442"
 
     # display the title as the primary caption
@@ -88,7 +88,7 @@ feature "Solr Document Block", feature: true do
     end
     # create the page
     save_page
-    
+
     # verify that the item + image widget is displaying image and title from the requested document.
     within(:css, ".items-block") do
       expect(page).to have_css(".thumbnail")
@@ -105,7 +105,7 @@ feature "Solr Document Block", feature: true do
     content_editable.set("zzz")
     # create the page
     save_page
-    
+
     # visit the show page for the document we just saved
     # verify that the item + image widget is displaying image and title from the requested document.
     within(:css, ".items-block") do
@@ -122,7 +122,7 @@ feature "Solr Document Block", feature: true do
     choose "Right"
     # create the page
     save_page
-    
+
     # verify that the item + image widget is displaying image and title from the requested document.
     within(:css, ".items-block") do
       expect(page).to have_content "zzz"
@@ -132,19 +132,19 @@ feature "Solr Document Block", feature: true do
 
   scenario "round-trip data", js: true do
     fill_in_typeahead_field with: "dq287tq6352"
-  
+
     within(:css, '.panel') do
       uncheck "Display?"
     end
 
     fill_in_typeahead_field with: "gk446cj2442"
-    
+
     # display the title as the primary caption
     within('.primary-caption') do
       check("Primary caption")
       select("Title", from: 'primary-caption-field')
     end
-    
+
     # fill in the content editable div
     content_editable = find(".st-text-block")
     content_editable.set("zzz")
@@ -156,7 +156,7 @@ feature "Solr Document Block", feature: true do
     click_on "Edit"
 
     expect(page).to have_selector ".panel", count: 2
-    
+
     # for some reason, the text area above isn't getting filled in
     # expect(page).to have_selector ".st-text-block", text: "zzz"
     expect(find_field("primary-caption-field").value).to eq "full_title_tesim"


### PR DESCRIPTION
Closes #871 

* Renamed widget titles to shorten and make more clear:

![curation_-_edit_page___bob_fitch_photography_archive_-_blacklight copy 2](https://cloud.githubusercontent.com/assets/101482/6630192/3f3aca52-c8d3-11e4-8169-cd5c57211bbd.png)

* Updated widget descriptions

* Updated widget configuration panels, mostly just to adding spacing and make minor alignment adjustments. I also made the widget titles to always show on open widgets, rather than just showing on hover. I don't see a drawback to doing this (but speak up if I'm missing something) and I think it helps if you forget what widget you're working with, or if you have several widgets open at once.

* I also added a placeholder in the item inputs to make it a little more obvious to a novice curator that they are supposed to type in there to find items.

A couple examples of the updated styling:

![curation_-_edit_page___bob_fitch_photography_archive_-_blacklight copy](https://cloud.githubusercontent.com/assets/101482/6630238/d6fb140a-c8d3-11e4-8c62-9d5e49582c76.png)
----

![curation_-_edit_page___bob_fitch_photography_archive_-_blacklight](https://cloud.githubusercontent.com/assets/101482/6630245/dd1dac1c-c8d3-11e4-8ac2-094a28797509.png)
