### PR TITLE
Make the default selection area for thumbs really large so when forms...

### DIFF
--- a/app/helpers/spotlight/jcrop_helper.rb
+++ b/app/helpers/spotlight/jcrop_helper.rb
@@ -20,7 +20,7 @@ module Spotlight
         bg_opacity: '.4',
         box_width: '600',
         aspect_ratio: 4.0 / 3.0,
-        initial_set_select: '[0, 0, 400, 300]'
+        initial_set_select: '[0, 0, 100000, 100000]'
       }
     end
   end


### PR DESCRIPTION
...are updated w/o updating the default crop we get the larges 4:3 image possible.

This was causing an issue when you would edit a browse category without updating the thumbnail (and would automatically crop the top left 400px by 300px as the thumbnail).  This thumb was particularly bad for large images.

Not sure if this is the best solution as it would probably be ideal to keep the original image when the user hans't cropped, but this is a simple solution for now.

## Before
![initial-selection-before](https://cloud.githubusercontent.com/assets/96776/6644129/ebb34ba6-c96e-11e4-860c-11d508af36e7.png)

## After
![initial-selection-after](https://cloud.githubusercontent.com/assets/96776/6644128/ebb171be-c96e-11e4-90e4-41d2bb973c5d.png)