### PR TITLE
Add form-observer data attribute to browse edit form...

### DIFF
--- a/app/assets/javascripts/spotlight/croppable.js
+++ b/app/assets/javascripts/spotlight/croppable.js
@@ -75,6 +75,7 @@ Spotlight.onLoad(function() {
         var jcrop_api = cropbox.data('Jcrop');
         if(jcrop_api) {
           jcrop_api.setSelect(options['setSelect']);
+          serializeObservedForms(observedForms());
         }
       });
 

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -1,4 +1,4 @@
-<%= bootstrap_form_for [@search.exhibit, @search], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-7', data: {autocomplete_exhibit_catalog_index_path: spotlight.autocomplete_exhibit_search_path(@search.exhibit, @search, q: "%QUERY", format: "json")}, html: {id: 'edit-search'} do |f| %>
+<%= bootstrap_form_for [@search.exhibit, @search], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-7', data: {form_observer: 'true', autocomplete_exhibit_catalog_index_path: spotlight.autocomplete_exhibit_search_path(@search.exhibit, @search, q: "%QUERY", format: "json")}, html: {id: 'edit-search'} do |f| %>
   <% if @search.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@search.errors.count, "error") %> prohibited this page from being saved:</h2>


### PR DESCRIPTION
...to alert when there are unsaved changes.

Closes #868 

![form-observer](https://cloud.githubusercontent.com/assets/96776/6644480/68496d9c-c971-11e4-8572-aee22d7a5b4f.gif)
