### PR TITLE
Hide sort and per-page widgets on the search results widget

### DIFF
--- a/app/views/spotlight/pages/_sort_and_per_page.html.erb
+++ b/app/views/spotlight/pages/_sort_and_per_page.html.erb
@@ -1,7 +1,0 @@
-<div id="sortAndPerPage" class="clearfix">
-  <div class="search-widgets pull-right">
-    <%= render :partial => 'sort_widget' %>
-    <%= render :partial => 'per_page_widget' %>
-    <%= render :partial => 'view_type_group', locals: { block: block } %>
-  </div>
-</div>

--- a/app/views/spotlight/sir_trevor/blocks/_search_results_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_search_results_block.html.erb
@@ -7,7 +7,16 @@
     </div>
   <%- else %>
       <% @response, @document_list = [response, document_list] %>
-      <%= render 'sort_and_per_page', block: search_results_block %>
+
+      <% views = blacklight_view_config_for_search_block(search_results_block) %>
+      <% if views.length > 1 -%>
+      <div id="sortAndPerPage" class="clearfix">
+        <div class="search-widgets pull-right">
+          <%= render partial: 'view_type_group', locals: { block: search_results_block } %>
+        </div>
+      </div>
+      <% end %>
+
       <%= render_document_index_with_view(block_document_index_view_type(search_results_block), document_list) %>
       <%= render 'results_pagination' %>
     </div>

--- a/spec/features/javascript/blocks/search_result_block_spec.rb
+++ b/spec/features/javascript/blocks/search_result_block_spec.rb
@@ -23,6 +23,9 @@ describe "Search Result Block", type: :feature, js: true do
     check "Slideshow"
 
     save_page
+
+    expect(page).not_to have_content "per page"
+    expect(page).not_to have_content "Sort by"
     
     # The two configured view types should be
     # present and the one not selected should not be


### PR DESCRIPTION
Fixes #826