### PR TITLE
Use ordinary facet and show fields for exhibit-specific tags

### DIFF
--- a/app/assets/stylesheets/spotlight/_catalog.scss
+++ b/app/assets/stylesheets/spotlight/_catalog.scss
@@ -104,3 +104,15 @@ form.edit_solr_document {
   float:left;
   margin-right: $padding-xs-horizontal;
 }
+
+#document {
+  dd.blacklight-exhibit_tags {
+    color: $body-bg;
+    line-height: 2em;
+  }
+
+  .blacklight-exhibit_tags a {
+    @extend .label;
+    @extend .label-default;
+  }
+}

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -81,7 +81,6 @@ class Spotlight::CatalogController < ::CatalogController
   def edit
     @response, @document = fetch params[:id]
     blacklight_config.view.edit.partials = blacklight_config.view_config(:show).partials.dup
-    blacklight_config.view.edit.partials.delete "spotlight/catalog/tags"
     blacklight_config.view.edit.partials.insert(2, :edit)
   end
 

--- a/app/models/concerns/spotlight/solr_document.rb
+++ b/app/models/concerns/spotlight/solr_document.rb
@@ -1,8 +1,7 @@
 module Spotlight
   module SolrDocument
     extend ActiveSupport::Concern
-    
-    include Blacklight::SearchHelper
+
     include Spotlight::SolrDocument::ActiveModelConcern
     include Spotlight::SolrDocument::Finder
     include Spotlight::SolrDocument::SpotlightImages

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -71,8 +71,6 @@ module Spotlight
 
         config.default_solr_params = config.default_solr_params.merge(default_solr_params)
 
-        config.show.partials.insert(2, "spotlight/catalog/tags")
-
         config.view.embed.partials ||= ['openseadragon']
         config.view.embed.if = false
         config.view.embed.locals ||= { osd_container_class: "" }
@@ -189,7 +187,8 @@ module Spotlight
 
     protected
     def add_exhibit_specific_fields config
-      config.add_facet_field Spotlight::SolrDocument.solr_field_for_tagger(exhibit), label: :'blacklight.search.fields.facet.exhibit_tag', show: false unless config.facet_fields.include? :exhibit_tag
+      config.add_show_field :exhibit_tags, field: Spotlight::SolrDocument.solr_field_for_tagger(exhibit), link_to_search: true unless config.show_fields.include? :exhibit_tags
+      config.add_facet_field :exhibit_tags, field: Spotlight::SolrDocument.solr_field_for_tagger(exhibit) unless config.facet_fields.include? :exhibit_tags
 
       exhibit.uploaded_resource_fields.each do |f|
         key = Array(f.solr_field || f.field_name).first.to_s

--- a/app/views/spotlight/catalog/_tags_default.html.erb
+++ b/app/views/spotlight/catalog/_tags_default.html.erb
@@ -1,5 +1,0 @@
-<ul class="tags">
-<% document.tags_from(current_exhibit).each do |tag| %>
-  <li><%= link_to tag, url_to_tag_facet(tag) %></li>
-<% end %>
-</ul>

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", "~> 4.0", ">= 4.2.0"
-  s.add_dependency "blacklight", "~> 5.11"
+  s.add_dependency "blacklight", "~> 5.12"
   s.add_dependency "autoprefixer-rails"
   s.add_dependency "cancancan"
   s.add_dependency "sir_trevor_rails", ">= 0.5.0a"

--- a/spec/features/exhibits/add_tags_spec.rb
+++ b/spec/features/exhibits/add_tags_spec.rb
@@ -22,10 +22,10 @@ describe "Add tags to an item in an exhibit", :type => :feature do
 
     visit spotlight.exhibit_catalog_path(exhibit, "dq287tq6352")
 
-    within("ul.tags") do
-      expect(page).to have_selector  "li", text: "One"
-      expect(page).to have_selector  "li", text: "Two and a half"
-      expect(page).to have_selector  "li", text: "Three"
+    within("dd.blacklight-exhibit_tags") do
+      expect(page).to have_selector  "a", text: "One"
+      expect(page).to have_selector  "a", text: "Two and a half"
+      expect(page).to have_selector  "a", text: "Three"
     end
 
     click_on "Two and a half"

--- a/spec/models/spotlight/blacklight_configuration_spec.rb
+++ b/spec/models/spotlight/blacklight_configuration_spec.rb
@@ -68,7 +68,7 @@ describe Spotlight::BlacklightConfiguration, :type => :model do
 
       expect(subject.blacklight_config.facet_fields.keys).to eq ['c', 'a', 'b']
     end
-    
+
     context "custom fields" do
       it "should include any custom fields" do
         allow(subject).to receive_messages(custom_facet_fields: { 'a' => double(if: nil, :if= => true, merge!: true, validate!: true, normalize!: true) })
@@ -81,7 +81,17 @@ describe Spotlight::BlacklightConfiguration, :type => :model do
         expect(subject.blacklight_config.facet_fields['a'].show).to be_falsey
       end
     end
-    
+
+    context "exhibit fields" do
+      before do
+        # undo the stubbing we've used elsewhere..
+        allow(subject).to receive(:default_blacklight_config).and_call_original
+        allow(Spotlight::Engine).to receive_messages blacklight_config: blacklight_config
+      end
+      it "should inject a tags facet" do
+        expect(subject.blacklight_config.facet_fields).to include "exhibit_tags"
+      end
+    end
   end
 
   describe "index fields" do
@@ -376,11 +386,6 @@ describe Spotlight::BlacklightConfiguration, :type => :model do
       blacklight_config.show.title_field = 'xyz'
       subject.show[:title_field] = 'abc'
       expect(subject.blacklight_config.show.title_field).to eq 'abc'
-    end
-
-    it "should inject partials" do
-      partials = subject.blacklight_config.show.partials
-      expect(partials).to include "spotlight/catalog/tags"
     end
   end
 


### PR DESCRIPTION
Requires https://github.com/projectblacklight/blacklight/pull/1149

Fixes #866 