### PR TITLE
Improve display of site masthead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ config/initializers/secret_token.rb
 spec/internal
 Gemfile.lock
 jetty
+_site/

--- a/app/assets/stylesheets/spotlight/_header.scss
+++ b/app/assets/stylesheets/spotlight/_header.scss
@@ -1,4 +1,4 @@
-$masthead-height: 120px;
+$masthead-height: 180px;
 $masthead-image-blur: 1px;
 
 @mixin masthead-background-containers() {
@@ -10,16 +10,38 @@ $masthead-image-blur: 1px;
   height: inherit;
 }
 
+@mixin masthead-navigation-menu() {
+  border: none;
+  border-radius: 0;
+  ul.nav.navbar-nav {
+    > li {
+      text-transform: uppercase;
+      a {
+        color: $gray-lighter;
+        letter-spacing: 1.2px;
+      }
+    }
+    a:hover {
+      background-color: rgba(255,255,255,0.15);
+    }
+    > .active > a {
+      background-color: rgba(255,255,255,0.3);
+      color: $white;
+    }
+  }
+}
+
 #exhibit-masthead, #exhibit-navbar {
   z-index: 1;
 }
 
 #exhibit-navbar {
   &.page-masthead {
-    background-color: $gray;
+    @include masthead-navigation-menu();
+    border-bottom: 1px solid $gray;
+    margin-top: 0;
     margin-bottom: 0;
-    border: 0;
-    border-radius: 0;
+    background-color: rgba(0,0,0,0.5);
     .navbar-nav {
       float: right;
     }
@@ -29,6 +51,15 @@ $masthead-image-blur: 1px;
       a {color: $gray-lighter;}
     }
   }
+  .navbar-form {
+    text-align: right;
+  }
+}
+
+#exhibit-masthead.with-image + #exhibit-navbar.navbar-default {
+  @include masthead-navigation-menu();
+  border-top: 1px solid $gray;
+  background-color: rgba(0,0,0,0.2);
 }
 
 .navbar + .navbar {
@@ -40,20 +71,26 @@ $masthead-image-blur: 1px;
 }
 
 #exhibit-masthead {
-  margin-bottom: 0;
-  padding: 0 0 24px 0;
+  margin-bottom: -50px;
+  padding: 0;
   position: static;
   height: $masthead-height;
   & > .container {
-    // Maintains the site title and subtitle at slightly below
-    // vertically-centered, even if height of masthead is changed.
     position: relative;
-    top: 60%;
+    top: 33%;
     -webkit-transform: translateY(-50%);
     transform: translateY(-50%);
   }
   &.with-page-masthead {
     margin-bottom: $padding-base-vertical;
+    margin-top: -51px;
+    > .container {
+      top: 60%;
+    }
+    .navbar-brand {
+      font-size: $font-size-large;
+      text-shadow: 1px 1px 0 $black;
+    }
     .search-title {
       text-align: center;
       small {
@@ -73,7 +110,7 @@ $masthead-image-blur: 1px;
   &.with-image {
     .site-title, .search-title {
       color: $white;
-      text-shadow: 0 1px 0 $black;
+      text-shadow: 2px 1px 0 $black;
     }
     small {
       color: $white;
@@ -146,6 +183,13 @@ $masthead-image-blur: 1px;
        rgba(0, 0, 0, 0.5)
      );
   }
+}
+
+// Margin between bottom of masthead and start of page content.
+// Need to apply bottom margin to different element, depending on
+// whether it is a regular masthead or a browse category masthead
+#exhibit-masthead + #exhibit-navbar, #exhibit-navbar + #exhibit-masthead {
+  margin-bottom: $padding-large-vertical * 2.5;
 }
 
 .col-md-4 {

--- a/app/helpers/spotlight/jcrop_helper.rb
+++ b/app/helpers/spotlight/jcrop_helper.rb
@@ -6,9 +6,9 @@ module Spotlight
         selector: 'masthead_image',
         bg_color: 'black',
         bg_opacity: '.4',
-        aspect_ratio: 15,
+        aspect_ratio: 10,
         box_width: '600',
-        initial_set_select: '[0, 0, 1800, 120]'
+        initial_set_select: '[0, 0, 1800, 180]'
       }
     end
 

--- a/app/uploaders/spotlight/masthead_uploader.rb
+++ b/app/uploaders/spotlight/masthead_uploader.rb
@@ -6,7 +6,7 @@ module Spotlight
 
     version :cropped do
       process crop: :image  ## Crops this version based on original image
-      process resize_to_fill: [1800, 120]
+      process resize_to_fill: [1800, 180]
     end
 
     def store_dir


### PR DESCRIPTION
Fixes #1126 

Changes masthead height to 180px (from 120px) but only increases total height of masthead+menu a little because this fix also moves the main menu nav on top of the image. This is the case for both the site masthead and the browse category masthead.

This might need some additional styling tweaking after I take a break from looking at it, and probably tweaking when used with the SUL theme. Also, I haven't handled responsiveness of the masthead/menu nav at smaller viewports, but will tackle that later with some other responsive issues.

### Site masthead examples

![maps_of_africa__an_online_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/6990013/58840220-da18-11e4-99e6-59a2fdd9f09c.png)
---

![maps_of_africa__an_online_exhibit_-_blacklight copy](https://cloud.githubusercontent.com/assets/101482/6990014/641a452c-da18-11e4-8bff-e35078829b92.png)
---

![maps_of_africa__an_online_exhibit_-_blacklight 4](https://cloud.githubusercontent.com/assets/101482/6990015/6db178d0-da18-11e4-95f6-9c5abab2cf3e.png)
---

### Browse category masthead example

![all_exhibit_items___maps_of_africa__an_online_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/6990017/79c65b4a-da18-11e4-839c-523bc8644908.png)

