### PR TITLE
Fix inconsistent column settings on feedback form

### DIFF
--- a/app/views/spotlight/shared/_report_a_problem.html.erb
+++ b/app/views/spotlight/shared/_report_a_problem.html.erb
@@ -2,7 +2,7 @@
 <div class="container">
 <div class="row">
   <% contact_form = Spotlight::ContactForm.new current_url: request.original_url %>
-  <%= bootstrap_form_for contact_form, url: spotlight.exhibit_contact_form_path(current_exhibit, contact_form), layout: :horizontal, label_col: 'col-md-3', control_col: 'col-sm-9', html: { class: 'col-md-offset-2 col-md-8 '} do |f| %>
+  <%= bootstrap_form_for contact_form, url: spotlight.exhibit_contact_form_path(current_exhibit, contact_form), layout: :horizontal, label_col: 'col-sm-3', control_col: 'col-sm-9', html: { class: 'col-md-offset-2 col-md-8 '} do |f| %>
 
     <h2><%= t(:'.title') %></h2>
     <%= f.text_field :name %>


### PR DESCRIPTION
Another minor update to fix the report a problem form layout, at medium viewport size (this wasn't apparent when manually resizing the browser width to medium, but was when I refreshed the page at medium width):

### Before:

![before2](https://cloud.githubusercontent.com/assets/101482/7304004/3e04580a-e9a9-11e4-92ce-9ce9d943ea62.png)

### After:

![after2](https://cloud.githubusercontent.com/assets/101482/7304007/41422312-e9a9-11e4-951a-9fb7640fed7a.png)
