### PR TITLE
Ensure 'no sidebar' page header and content is wrapped in column class

### DIFF
--- a/app/views/spotlight/pages/show.html.erb
+++ b/app/views/spotlight/pages/show.html.erb
@@ -3,7 +3,7 @@
 <%= render 'sidebar' if @page.display_sidebar? %>
 
 <%= cache_unless current_user, @page do %>
-<div class="<%= 'col-md-9' if @page.display_sidebar? %>">
+<div class="<%= @page.display_sidebar? ? 'col-md-9' : 'col-md-12' %>">
   <div class="clearfix">
     <%= render 'edit_page_link' if can? :edit, @page %>
     <% if @page.should_display_title? %>


### PR DESCRIPTION
Added column class when there is no sidebar, which gives the page title and content the default 15px left-padding to left-align the content as expected.

### Before

![feature_page_one___default_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/7308002/7192dfd6-e9c5-11e4-8f21-dd26b6c2534c.png)

### After

![after](https://cloud.githubusercontent.com/assets/101482/7308062/f653a796-e9c5-11e4-8ec0-4998d3e0dcaa.png)

