### PR TITLE
Item grid widget layout updates

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -166,10 +166,12 @@
         height: 240px;
       }
     }
-
   }
   @media (max-width: $screen-sm-max) {
-    .items-col {margin-bottom: $line-height-computed;}
+    &.items-block .items-col {margin-bottom: $line-height-computed;}
+  }
+  @media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+    &.items-block .items-col .box {min-width: 128px;}
   }
 }
 

--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -145,7 +145,11 @@
       min-width: 25%;
       height: 120px;
       @media (min-width: $screen-lg-min) {
-        height: 135px;
+        height: 170px; // default: no sidebar, no text column
+        // reduce height if on a page with a sidebar or text column, because will be less wide
+        .col-md-9 & {
+          height: 135px;
+        }
       }
       padding: 5px;
     }
@@ -161,9 +165,12 @@
     .item-0, .item-1, .item-2 {
       height: 220px;
       order: 0;
-
       @media (min-width: $screen-lg-min) {
-        height: 240px;
+        height: 280px; // default: no sidebar, no text column
+        // reduce height if on a page with a sidebar or text column, because will be less wide
+        .col-md-9 & {
+          height: 240px;
+        }
       }
     }
   }
@@ -239,6 +246,9 @@
         img {
           height: 250px;
           object-fit: cover;
+          @media (max-width: $screen-sm-max) {
+            height: 175px;
+          }
         }
       }
     }

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
@@ -1,6 +1,6 @@
 <% solr_documents_grid_block.with_solr_helper(self) %>
 <div class="content-block items-block item-grid-block row">
-  <div class="items-col col-md-9 pull-<%= solr_documents_grid_block.content_align %>">
+  <div class="items-col <%= solr_documents_grid_block.text? ? 'col-md-9' : 'col-md-12' %> pull-<%= solr_documents_grid_block.content_align %>">
     <% if solr_documents_grid_block.documents? %>
         <% solr_documents_grid_block.documents.each_with_index do |document, index| %>
           <div class="box item-<%= index %>" data-id="<%= document.id %>">
@@ -14,7 +14,7 @@
     <% end %>
   </div>
 
-  
+
   <% if solr_documents_grid_block.text? %>
     <div class="text-col col-md-3">
       <% unless solr_documents_grid_block.title.blank? %>


### PR DESCRIPTION
Fixes #1144 

* Check to see if Item Grid has a text block. If not, make the items column take 12 columns instead of 9, so it uses full width of content area

## Before

![before3](https://cloud.githubusercontent.com/assets/101482/7354789/8801e572-ecd2-11e4-81da-1d1ee650601e.png)

### After

![after3](https://cloud.githubusercontent.com/assets/101482/7354796/92af2da4-ecd2-11e4-9ad1-128231b35ded.png)
---

* Adjust size of Item Grid boxes to fit more appropriately in available space, depending on whether the page has a sidebar and whether the Item Grid has an associated text block

### Before

![before](https://cloud.githubusercontent.com/assets/101482/7354762/6e221a8c-ecd2-11e4-85f2-e114afabd77e.png)

### After

![after](https://cloud.githubusercontent.com/assets/101482/7354770/78302316-ecd2-11e4-9e45-8b4a4bea3be5.png)


