### PR TITLE
available_index_fields helper should use blacklight_config

### DIFF
--- a/app/helpers/spotlight/pages_helper.rb
+++ b/app/helpers/spotlight/pages_helper.rb
@@ -10,9 +10,8 @@ module Spotlight
     end
 
     def available_index_fields
-      index_fields = @page.exhibit.blacklight_configuration.default_blacklight_config.index_fields
-      fields = index_fields.map { |k, _v| { key: k, label: index_field_label(nil, k) } }
-      fields.unshift(key: document_show_link_field, label: t(:'.title_placeholder')) unless index_fields.include? document_show_link_field
+      fields = blacklight_config.index_fields.map { |k, _v| { key: k, label: index_field_label(nil, k) } }
+      fields.unshift(key: document_show_link_field, label: t(:'spotlight.pages.form.title_placeholder')) unless index_fields.include? document_show_link_field
 
       fields
     end

--- a/spec/helpers/spotlight/pages_helper_spec.rb
+++ b/spec/helpers/spotlight/pages_helper_spec.rb
@@ -13,6 +13,21 @@ module Spotlight
       allow(helper).to receive_messages(blacklight_config: blacklight_config)
     end
 
+    describe 'available_index_fields' do
+      before do
+        blacklight_config.index.title_field = :title_field
+        blacklight_config.add_index_field 'x', label: 'X'
+      end
+
+      it 'lists the configured index fields' do
+        expect(helper.available_index_fields).to include key: 'x', label: 'X'
+      end
+
+      it 'adds the title field if necessary' do
+        expect(helper.available_index_fields).to include key: :title_field, label: 'Title'
+      end
+    end
+
     describe 'disable_save_pages_button?' do
       it 'returns true if there are no pages and we are on the about pages page' do
         expect(helper).to receive(:page_collection_name).and_return('about_pages')


### PR DESCRIPTION
`available_index_fields` includes exhibit-specific fields. Fixes #1147