### PR TITLE
Ensure wrapped contact text fields left align in sidebar

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -103,11 +103,11 @@
 }
 
 .contact-photo {
-    border: 1px solid #CCC;
-    border-radius: $border-radius-base;
-    float: left;
-    margin-right: 15px;
-    margin-top: 3px;
+  border: 1px solid #CCC;
+  border-radius: $border-radius-base;
+  float: left;
+  margin-right: 15px;
+  margin-top: 3px;
 }
 
 // Indent contact fields so they align evenly, only when there is a contact photo

--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -104,8 +104,15 @@
 
 .contact-photo {
     border: 1px solid #CCC;
+    border-radius: $border-radius-base;
     float: left;
     margin-right: 15px;
+    margin-top: 3px;
+}
+
+// Indent contact fields so they align evenly, only when there is a contact photo
+.sidenav.contacts .contact-photo + div[itemprop] ~ div[itemprop] {
+  margin-left: 87px;
 }
 
 .item-grid-block {

--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -103,7 +103,7 @@
 }
 
 .contact-photo {
-  border: 1px solid #CCC;
+  border: 1px solid #ccc;
   border-radius: $border-radius-base;
   float: left;
   margin-right: 15px;


### PR DESCRIPTION
Longer text fields used for exhibit contacts wrap under the contact photo, which can create a somewhat disjointed appearance, which as the second contact in this example:

![before](https://cloud.githubusercontent.com/assets/101482/7575013/813a6e3e-f7e6-11e4-9833-d748c7953dc2.png)

This commit indents the text fields when there is a contact photo to avoid the wrapping:

![after](https://cloud.githubusercontent.com/assets/101482/7575021/96e3bfce-f7e6-11e4-8299-5c6d89711eaa.png)

If a contact doesn't include a photo, the text is not indented:

![after2](https://cloud.githubusercontent.com/assets/101482/7575032/a966b25a-f7e6-11e4-8776-cacf0b4f3cc8.png)
