### PR TITLE
Stub out fixtures that trigger solr requests in tests

### DIFF
--- a/spec/factories/exhibits.rb
+++ b/spec/factories/exhibits.rb
@@ -3,4 +3,8 @@ FactoryGirl.define do
     sequence(:title) { |n| "Exhibit Title #{n}" }
     after(:build) { |exhibit| exhibit.searches << FactoryGirl.build(:default_search) }
   end
+
+  factory :default_exhibit, parent: :exhibit do
+    default true
+  end
 end

--- a/spec/factories/searches.rb
+++ b/spec/factories/searches.rb
@@ -2,11 +2,11 @@ FactoryGirl.define do
   factory :search, class: Spotlight::Search do
     exhibit
     title 'Search1'
+
+    after(:build) { |search| search.thumbnail = FactoryGirl.create(:featured_image) }
   end
 
-  factory :published_search, class: Spotlight::Search do
-    exhibit
-    title 'Search1'
+  factory :published_search, parent: :search do
     published true
   end
 

--- a/spec/features/about_page_spec.rb
+++ b/spec/features/about_page_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'About page', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let!(:about_page1) { FactoryGirl.create(:about_page, title: 'First Page', exhibit: exhibit) }
   let!(:about_page2) { FactoryGirl.create(:about_page, title: 'Second Page', exhibit: exhibit) }

--- a/spec/features/add_custom_field_metadata_spec.rb
+++ b/spec/features/add_custom_field_metadata_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Adding custom metadata field data', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
   let(:custom_field) { FactoryGirl.create(:custom_field, exhibit: exhibit) }
   let(:config) { exhibit.blacklight_configuration }

--- a/spec/features/add_item_bookmarklet_spec.rb
+++ b/spec/features/add_item_bookmarklet_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'adding an item using the provided bookmarklet', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let(:search) { exhibit.searches.first }
   before { login_as curator }

--- a/spec/features/browse_category_admin_spec.rb
+++ b/spec/features/browse_category_admin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Browse Category Administration', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let!(:search) { FactoryGirl.create(:search, exhibit: exhibit, query_params: { f: { 'genre_ssim' => ['Value'] } }) }
   before { login_as curator }

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Catalog', type: :feature do
   describe 'admin' do
-    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    let(:exhibit) { FactoryGirl.create(:default_exhibit) }
     let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
 
     before do

--- a/spec/features/confirm_email_spec.rb
+++ b/spec/features/confirm_email_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Confirming an email', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:contact_email) { Spotlight::ContactEmail.create!(email: 'justin@example.com', exhibit: exhibit) }
   let(:raw_token) { contact_email.instance_variable_get(:@raw_confirmation_token) }
 

--- a/spec/features/create_exhibit_spec.rb
+++ b/spec/features/create_exhibit_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 describe 'Create a new exhibit', type: :feature do
   let(:user) { FactoryGirl.create(:site_admin) }
-  before { login_as user }
+  before do
+    allow_any_instance_of(Spotlight::Search).to receive(:set_default_featured_image)
+    login_as user
+  end
 
   it 'has a link in the user dropdown' do
     visit '/'

--- a/spec/features/create_page_spec.rb
+++ b/spec/features/create_page_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Creating a page', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
 
   describe 'when a bunch of about pages exist' do

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Dashboard', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
   before do
     login_as(admin)

--- a/spec/features/edit_sort_fields_spec.rb
+++ b/spec/features/edit_sort_fields_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Sort Fields Administration', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as exhibit_curator }
 

--- a/spec/features/exhibits/add_tags_spec.rb
+++ b/spec/features/exhibits/add_tags_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Add tags to an item in an exhibit', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let(:custom_field) { FactoryGirl.create(:custom_field, exhibit: exhibit) }
 

--- a/spec/features/exhibits/administration_spec.rb
+++ b/spec/features/exhibits/administration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Exhibit Administration', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
   let(:email_id_0) { 'exhibit_contact_emails_attributes_0_email' }
   let(:email_address_0) { 'admin@example.com' }

--- a/spec/features/exhibits/custom_metadata_fields_spec.rb
+++ b/spec/features/exhibits/custom_metadata_fields_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Adding custom metadata fields', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
 
   before do

--- a/spec/features/exhibits/edit_facet_fields_spec.rb
+++ b/spec/features/exhibits/edit_facet_fields_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Editing metadata fields', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
   before { login_as(admin) }
 

--- a/spec/features/exhibits/edit_metadata_fields_spec.rb
+++ b/spec/features/exhibits/edit_metadata_fields_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Editing metadata fields', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
   before { login_as(admin) }
 

--- a/spec/features/feature_page_spec.rb
+++ b/spec/features/feature_page_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Feature page', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   describe 'sidebar' do
     let!(:parent_feature_page) do

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 describe 'Home page', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as exhibit_curator }
   it 'exists by default on exhibits' do

--- a/spec/features/import_exhibit_spec.rb
+++ b/spec/features/import_exhibit_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'tempfile'
 
 describe 'Allow exhibit admins to import and export content from an exhibit', type: :feature, js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
   before { login_as user }
 

--- a/spec/features/item_admin_spec.rb
+++ b/spec/features/item_admin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Item Administration', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as curator }
 

--- a/spec/features/javascript/about_page_admin_spec.rb
+++ b/spec/features/javascript/about_page_admin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'About Pages Adminstration', js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as exhibit_curator }
 

--- a/spec/features/javascript/block_controls_spec.rb
+++ b/spec/features/javascript/block_controls_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Block controls' do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as exhibit_curator }
 

--- a/spec/features/javascript/blocks/featured_browse_categories_block_spec.rb
+++ b/spec/features/javascript/blocks/featured_browse_categories_block_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Featured Browse Category Block', type: :feature, js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
 
   let!(:feature_page) { FactoryGirl.create(:feature_page, exhibit: exhibit) }

--- a/spec/features/javascript/blocks/featured_pages_block_spec.rb
+++ b/spec/features/javascript/blocks/featured_pages_block_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Featured Pages Blocks', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let!(:feature_page) do
     FactoryGirl.create(
       :feature_page,

--- a/spec/features/javascript/blocks/search_result_block_spec.rb
+++ b/spec/features/javascript/blocks/search_result_block_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Search Result Block', type: :feature, js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
 
   let!(:feature_page) { FactoryGirl.create(:feature_page, exhibit: exhibit) }

--- a/spec/features/javascript/blocks/solr_documents_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_block_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Solr Document Block', feature: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let(:feature_page) do
     FactoryGirl.create(

--- a/spec/features/javascript/edit_in_place_spec.rb
+++ b/spec/features/javascript/edit_in_place_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Edit in place', type: :feature, js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
   before { login_as admin }
   describe 'Feature Pages' do

--- a/spec/features/javascript/facet_admin_spec.rb
+++ b/spec/features/javascript/facet_admin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Facets Administration', js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as exhibit_curator }
   it 'allows us to update the label with edit-in-place' do

--- a/spec/features/javascript/feature_page_admin_spec.rb
+++ b/spec/features/javascript/feature_page_admin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Feature Pages Adminstration', js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let!(:page1) do
     FactoryGirl.create(

--- a/spec/features/javascript/home_page_edit_spec.rb
+++ b/spec/features/javascript/home_page_edit_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Editing the Home Page', js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
 
   before { login_as admin }

--- a/spec/features/javascript/metadata_admin_spec.rb
+++ b/spec/features/javascript/metadata_admin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Metadata Administration', js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
   before { login_as admin }
   describe 'Select/Deselect all button' do

--- a/spec/features/javascript/multi_image_select_spec.rb
+++ b/spec/features/javascript/multi_image_select_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Multi image selector', type: :feature, js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let(:feature_page) { FactoryGirl.create(:feature_page, exhibit: exhibit) }
   before { login_as exhibit_curator }

--- a/spec/features/javascript/preview_block_spec.rb
+++ b/spec/features/javascript/preview_block_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Block preview' do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let(:feature_page) do
     FactoryGirl.create(

--- a/spec/features/javascript/rule_block_spec.rb
+++ b/spec/features/javascript/rule_block_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Horizontal rule block', type: :feature, js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let!(:feature_page) { FactoryGirl.create(:feature_page, exhibit: exhibit) }
   before { login_as exhibit_curator }

--- a/spec/features/javascript/search_context_spec.rb
+++ b/spec/features/javascript/search_context_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Search contexts' do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let(:feature_page) do
     FactoryGirl.create(

--- a/spec/features/main_navigation_spec.rb
+++ b/spec/features/main_navigation_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Main navigation labels are settable', type: :feature do
-  let!(:exhibit) { FactoryGirl.create(:exhibit) }
+  let!(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let!(:about) { FactoryGirl.create(:about_page, exhibit: exhibit, published: true) }
   before do
     about_nav = exhibit.main_navigations.about

--- a/spec/features/metadata_admin_spec.rb
+++ b/spec/features/metadata_admin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Metadata Administration', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as exhibit_curator }
 

--- a/spec/features/multiple_exhibits_spec.rb
+++ b/spec/features/multiple_exhibits_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe 'Home page', type: :feature do
   let(:exhibit_visitor) { FactoryGirl.create(:exhibit_visitor) }
-  let!(:default_exhibit) { Spotlight::Exhibit.default }
+  let!(:default_exhibit) { FactoryGirl.create(:default_exhibit, title: 'Default exhibit') }
   let!(:second_exhibit) { FactoryGirl.create(:exhibit, title: 'Second exhibit') }
 
   before { login_as exhibit_visitor }

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Report a Problem', type: :feature do
-  let!(:exhibit) { FactoryGirl.create(:exhibit) }
+  let!(:exhibit) { FactoryGirl.create(:default_exhibit) }
   it 'does not have a header link' do
     visit root_path
     expect(page).to_not have_content 'Feedback'

--- a/spec/features/search_facets_admin_spec.rb
+++ b/spec/features/search_facets_admin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Search Facets Administration', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as exhibit_curator }
 

--- a/spec/features/site_masthead_spec.rb
+++ b/spec/features/site_masthead_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Add and update the site masthead', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
 
   before { login_as user }

--- a/spec/features/slideshow_spec.rb
+++ b/spec/features/slideshow_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Slideshow', type: :feature, js: true do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
 
   before do

--- a/spec/features/tags_admin_spec.rb
+++ b/spec/features/tags_admin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Tags Administration', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let!(:tagging) { FactoryGirl.create(:tagging, tagger: exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as exhibit_curator }

--- a/spec/features/update_appearance_spec.rb
+++ b/spec/features/update_appearance_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Update the appearance', type: :feature do
-  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
 
   before { login_as user }

--- a/spec/features/upload_non_repository_item_spec.rb
+++ b/spec/features/upload_non_repository_item_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Uploading a non-repository item', type: :feature do
-  let!(:exhibit) { FactoryGirl.create(:exhibit) }
+  let!(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let!(:custom_field) { FactoryGirl.create(:custom_field, exhibit: exhibit) }
   let!(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   before { login_as exhibit_curator }

--- a/spec/features/user_admin_spec.rb
+++ b/spec/features/user_admin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'User Administration', type: :feature do
-  let!(:exhibit) { FactoryGirl.create(:exhibit) }
+  let!(:exhibit) { FactoryGirl.create(:default_exhibit) }
   let!(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
   before { login_as user }
   describe 'index' do

--- a/spec/models/spotlight/ability_spec.rb
+++ b/spec/models/spotlight/ability_spec.rb
@@ -3,7 +3,7 @@ require 'cancan/matchers'
 
 describe Spotlight::Ability, type: :model do
   before do
-    allow_any_instance_of(Spotlight::Search).to receive(:default_featured_image)
+    allow_any_instance_of(Spotlight::Search).to receive(:set_default_featured_image)
   end
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:search) { FactoryGirl.create(:published_search, exhibit: exhibit) }

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spotlight::Exhibit, type: :model do
-  subject { described_class.new(title: 'Sample') }
+  subject { FactoryGirl.build(:exhibit, title: 'Sample') }
 
   it 'has a title' do
     subject.title = 'Test title'
@@ -48,7 +48,7 @@ describe Spotlight::Exhibit, type: :model do
   end
 
   describe '#main_navigations' do
-    subject { described_class.new(title: 'Sample').tap(&:save!) }
+    subject { FactoryGirl.create(:exhibit, title: 'Sample') }
     it 'has main navigations' do
       expect(subject.main_navigations).to have(3).main_navigations
       expect(subject.main_navigations.map(&:label).compact).to be_blank

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spotlight::Search, type: :model do
   let(:query_params) { { 'f' => { 'genre_sim' => ['map'] } } }
-  subject { FactoryGirl.build(:search, query_params: query_params) }
+  subject { FactoryGirl.create(:exhibit).searches.build(title: 'Search', query_params: query_params) }
 
   let(:blacklight_config) { ::CatalogController.blacklight_config }
   let(:document) do

--- a/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
+++ b/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 describe Spotlight::ExhibitExportSerializer do
   let!(:source_exhibit) { FactoryGirl.create(:exhibit) }
 
+  before do
+    allow_any_instance_of(Spotlight::Search).to receive(:set_default_featured_image)
+    allow_any_instance_of(SolrDocument).to receive(:reindex)
+    allow_any_instance_of(Spotlight::Resource).to receive(:reindex)
+  end
+
   subject { JSON.parse(described_class.new(source_exhibit).to_json) }
 
   it 'does not include unique identifiers' do

--- a/spec/views/spotlight/searches/_search.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/_search.html.erb_spec.rb
@@ -2,20 +2,21 @@ require 'spec_helper'
 
 describe 'spotlight/searches/_search.html.erb', type: :view do
   let(:search) do
-    stub_model(Spotlight::Search, exhibit: FactoryGirl.create(:exhibit),
-                                  id: 99,
-                                  title: 'Title1',
-                                  query_params: {
-                                    f: {
-                                      genre_ssim: ['xyz']
-                                    }
-                                  })
+    FactoryGirl.build_stubbed(:search, exhibit: FactoryGirl.create(:exhibit),
+                                       id: 99,
+                                       title: 'Title1',
+                                       query_params: {
+                                         f: {
+                                           genre_ssim: ['xyz']
+                                         }
+                                       })
   end
 
   before do
     allow(view).to receive(:edit_search_path).and_return('/edit')
     allow(view).to receive(:search_path).and_return('/search')
     allow(search).to receive_message_chain(:thumbnail, :image, thumb: '/some/image')
+    allow(search).to receive(:count).and_return(15)
     allow(search).to receive(:params).and_return({})
 
     form_for(search, url: '/update') do |f|


### PR DESCRIPTION
These seem to halve the `rake ci` (from 10m -> 5m on travis, and even shorter locally)