### PR TITLE
Removes SU list notifications for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ rvm:
 
 notifications:
   irc: "irc.freenode.org#blacklight"
-  email:
-      - exhibits-team@lists.stanford.edu
 
 env:
   global:


### PR DESCRIPTION
Do we really need to alert this list for travis builds?