### PR TITLE
Pull batch indexing and exhibit-specific data logic up from spotlight-dor-resources

### DIFF
--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -56,6 +56,8 @@ module Spotlight
     Spotlight::Engine.config.resource_providers = []
     Spotlight::Engine.config.new_resource_partials = [] # e.g. "spotlight/resources/bookmarklet"
     Spotlight::Engine.config.uploaded_resource_partials = ['spotlight/resources/upload/single_item_form', 'spotlight/resources/upload/multi_item_form']
+    Spotlight::Engine.config.solr_batch_size = 20
+
     # Filter resources by exhibit by default
     Spotlight::Engine.config.filter_resources_by_exhibit = true
     # The allowed file extensions for uploading non-repository items.

--- a/spec/models/spotlight/resources/open_graph_spec.rb
+++ b/spec/models/spotlight/resources/open_graph_spec.rb
@@ -12,7 +12,7 @@ describe Spotlight::Resources::OpenGraph, type: :model do
 
   describe '#to_solr' do
     before do
-      allow(subject).to receive_messages id: 15, opengraph_properties: {}, exhibit: exhibit
+      allow(subject).to receive_messages id: 15, opengraph_properties: {}, exhibit: exhibit, persisted?: true
     end
 
     let(:solr_doc) { subject.to_solr }


### PR DESCRIPTION
I hope this will let us simplify `Spotlight::Resources::DorResource` to just the glue code with `gdor-indexer`.