### PR TITLE
Update text to clarify options for displaying search options

### DIFF
--- a/app/views/spotlight/search_configurations/_search_fields.html.erb
+++ b/app/views/spotlight/search_configurations/_search_fields.html.erb
@@ -1,14 +1,13 @@
 <% default_field = @blacklight_configuration.blacklight_config.default_search_field %>
+<div class="checkbox">
+  <label>
+    <%= check_box_tag :enable_feature, '1', @blacklight_configuration.blacklight_config.search_fields.select { |_k, v| v.enabled && v.include_in_simple_select != false }.any?, data: { behavior: 'enable-feature', target: '#search_fields' } %> <%= t(:'.enable_feature') %>
+  </label>
+</div>
+
 <%= field_set_tag(t(:'.header'), id: 'search_fields') do %>
   <p class="instructions"><%= t(:'.help') %></p>
   <p class="instructions"><%= t(:'.instructions') %></p>
-  <p class="instructions">
-    <div class="checkbox">
-      <label>
-        <%= check_box_tag :enable_feature, '1', @blacklight_configuration.blacklight_config.search_fields.select { |_k, v| v.enabled && v.include_in_simple_select != false }.any?, data: { behavior: 'enable-feature', target: '#search_fields' } %> <%= t(:'.enable_feature') %>
-      </label>
-    </div>
-  </p>
 
   <%= f.fields_for :search_fields, @blacklight_configuration.blacklight_config.search_fields.keys do |vt| %>
     <ol class="dd-list col-md-7 disabled-search-option search_fields_admin">
@@ -39,7 +38,7 @@
                   <div class="row">
                     <div class="col-sm-12">
                       <%= vt.fields_for k, config do |field| %>
-                        <%= field.check_box_without_bootstrap :enabled  %>
+                        <%= field.check_box_without_bootstrap :enabled %>
                         <h3 class="panel-title" data-in-place-edit-target=".edit-in-place" data-in-place-edit-field-target="[data-edit-field-target='true']">
                           <a href="#edit-in-place" class="field-label edit-in-place"><%= config.label %></a>
                           <%= field.hidden_field :label, {data: {:"edit-field-target" => "true"}} %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -165,13 +165,14 @@ en:
       search_fields:
         header: "Field-based search"
         help: >
-          Enable field-based search to add a dropdown menu to your exhibit sites search box that
+          If the search box is displayed, you can also enable field-based search.
+          Field-based search adds a dropdown menu to your exhibit site's search box that
           provides the user with an option to restrict a search query to a single metadata field.
         instructions: >
-          If enabled, you can select the metadata fields that are available for searching. Click
+          If enabled, you can select below the metadata fields that are available for searching. Click
           a field name to edit its display label.  Drag and drop fields to specify the order they
           are displayed in the search box dropdown menu.
-        enable_feature: Enable field-based search
+        enable_feature: Display search box
       facets:
         help: >
           If the sidebar is visible, users can use

--- a/spec/features/javascript/search_config_admin_spec.rb
+++ b/spec/features/javascript/search_config_admin_spec.rb
@@ -17,7 +17,7 @@ feature 'Search Configuration Administration', js: true do
       click_link 'Search'
       click_link 'Options'
 
-      uncheck 'Enable field-based search'
+      uncheck 'Display search box'
 
       click_button 'Save changes'
 


### PR DESCRIPTION
Closes #1222 

Moved and renamed the checkbox that enables the search box. Minor update to instructions text to reflect renamed checkbox.

--
### Before
![before](https://cloud.githubusercontent.com/assets/101482/11257094/71085134-8e04-11e5-98a2-d56db615f65f.png)
--
### After
![after](https://cloud.githubusercontent.com/assets/101482/11257123/933c64e8-8e04-11e5-8ad9-4c22c440db12.png)
