### PR TITLE
Use a different template for the spotlight home page

### DIFF
--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -8,7 +8,11 @@ module Spotlight
     load_and_authorize_resource
 
     def index
-      redirect_to @exhibits.first if @exhibits.one?
+      if @exhibits.one?
+        redirect_to @exhibits.first
+      else
+        render layout: 'spotlight/home'
+      end
     end
 
     def new

--- a/app/views/layouts/spotlight/home.html.erb
+++ b/app/views/layouts/spotlight/home.html.erb
@@ -1,0 +1,1 @@
+<%= render template: 'layouts/spotlight/spotlight' %>

--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -30,28 +30,17 @@
 
   </head>
   <body class="<%= render_body_class %>">
-  <%= render :partial => 'shared/header_navbar' %>
+  <%= render partial: 'shared/header_navbar' %>
+  <%= render partial: 'shared/exhibit_masthead_and_navbar' %>
+  <%= content_for?(:header_content) ? yield(:header_content) : "" %>
 
+  <%= render partial: 'shared/ajax_modal' %>
 
-  <div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal menu" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-      </div>
-    </div>
-  </div>
-
-<!-- /container -->
   <div id="main-container" class="container">
-    <div class="row">
-      <div class="col-md-12">
-        <div id="main-flashes">
-          <%= render :partial=>'/flash_msg' %>
-        </div>
-      </div>
-    </div>
+    <%= render partial: 'shared/flash_messages' %>
 
     <div class="row">
-      <%= yield %>
+      <%= content_for?(:content) ? yield(:content) : yield %>
     </div>
   </div>
 

--- a/app/views/shared/_exhibit_masthead_and_navbar.html.erb
+++ b/app/views/shared/_exhibit_masthead_and_navbar.html.erb
@@ -1,0 +1,9 @@
+<%= render 'shared/exhibit_navbar' unless exhibit_masthead? %>
+<% if current_exhibit %>
+  <%= render 'spotlight/shared/report_a_problem' if show_contact_form? %>
+  <%= render 'shared/exhibit_masthead' %>
+<% end %>
+<% if exhibit_masthead? %>
+  <%= render 'shared/exhibit_navbar' %>
+  <%= render 'shared/breadcrumbs' %>
+<% end %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,7 @@
+<div class="row">
+  <div class="col-md-12">
+    <div id="main-flashes">
+      <%= render :partial=>'/flash_msg' %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -15,13 +15,3 @@
     </div>
   </div>
 </div>
-
-<%= render 'shared/exhibit_navbar' unless exhibit_masthead? %>
-<% if current_exhibit %>
-  <%= render 'spotlight/shared/report_a_problem' if show_contact_form? %>
-  <%= render 'shared/exhibit_masthead' %>
-<% end %>
-<% if exhibit_masthead? %>
-  <%= render 'shared/exhibit_navbar' %>
-  <%= render 'shared/breadcrumbs' %>
-<% end %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,0 +1,6 @@
+<div id="ajax-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal menu" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+    </div>
+  </div>
+</div>

--- a/spec/views/shared/_exhibit_masthead_and_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_exhibit_masthead_and_navbar.html.erb_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+module Spotlight
+  describe 'shared/_exhibit_masthead_and_navbar', type: :view do
+    let(:current_exhibit) { FactoryGirl.create(:exhibit) }
+    let(:masthead) { 'exhibit-masthead' }
+    let(:navbar) { 'exhibit-navbar' }
+    let(:breadcrumbs) { 'exhibit-breadcrumbs' }
+    before do
+      stub_template '_user_util_links.html.erb' => 'links'
+      stub_template 'shared/_exhibit_masthead.html.erb' => masthead
+      stub_template 'shared/_exhibit_navbar.html.erb' => navbar
+      stub_template 'shared/_breadcrumbs.html.erb' => breadcrumbs
+      allow(view).to receive_messages(exhibit_masthead?: true)
+      allow(view).to receive_messages(current_exhibit: current_exhibit)
+    end
+    it 'renders the masthead above the navbar' do
+      render
+      expect(rendered.index(masthead)).to be < rendered.index(navbar)
+    end
+    it 'renders the navbar above the search masthead' do
+      allow(view).to receive_messages(exhibit_masthead?: false)
+      render
+      expect(rendered.index(navbar)).to be < rendered.index(masthead)
+    end
+    it 'renders the breadcrumbs' do
+      render
+      expect(rendered).to have_content(breadcrumbs)
+    end
+    it 'does not render breadcrumbs when there is a search masthead' do
+      allow(view).to receive_messages(exhibit_masthead?: false)
+      render
+      expect(rendered).to_not have_content(breadcrumbs)
+    end
+  end
+end

--- a/spec/views/shared/_header_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_header_navbar.html.erb_spec.rb
@@ -2,35 +2,13 @@ require 'spec_helper'
 
 module Spotlight
   describe 'shared/_header_navbar', type: :view do
-    let(:current_exhibit) { FactoryGirl.create(:exhibit) }
-    let(:masthead) { 'exhibit-masthead' }
-    let(:navbar) { 'exhibit-navbar' }
-    let(:breadcrumbs) { 'exhibit-breadcrumbs' }
     before do
       stub_template '_user_util_links.html.erb' => 'links'
-      stub_template 'shared/_exhibit_masthead.html.erb' => masthead
-      stub_template 'shared/_exhibit_navbar.html.erb' => navbar
-      stub_template 'shared/_breadcrumbs.html.erb' => breadcrumbs
-      allow(view).to receive_messages(exhibit_masthead?: true)
-      allow(view).to receive_messages(current_exhibit: current_exhibit)
     end
-    it 'renders the masthead above the navbar' do
+
+    it 'has nav links' do
       render
-      expect(rendered.index(masthead)).to be < rendered.index(navbar)
-    end
-    it 'renders the navbar above the search masthead' do
-      allow(view).to receive_messages(exhibit_masthead?: false)
-      render
-      expect(rendered.index(navbar)).to be < rendered.index(masthead)
-    end
-    it 'renders the breadcrumbs' do
-      render
-      expect(rendered).to have_content(breadcrumbs)
-    end
-    it 'does not render breadcrumbs when there is a search masthead' do
-      allow(view).to receive_messages(exhibit_masthead?: false)
-      render
-      expect(rendered).to_not have_content(breadcrumbs)
+      expect(rendered).to have_selector '#user-util-collapse', text: 'links'
     end
   end
 end


### PR DESCRIPTION
This allows us to easily customize the home page downstream