### PR TITLE
Add translations for search results config form labels

### DIFF
--- a/app/views/spotlight/search_configurations/_default_per_page.html.erb
+++ b/app/views/spotlight/search_configurations/_default_per_page.html.erb
@@ -1,4 +1,4 @@
-<%= f.form_group :default_per_page, label: { text: t(:'.default_per_page')} do %>
+<%= f.form_group :default_per_page, label: { text: t(:'.label')} do %>
   <% @blacklight_configuration.default_blacklight_config.per_page.each do |key| %>
     <%= f.radio_button :default_per_page, key, label: key.to_s %>
   <% end %>

--- a/app/views/spotlight/search_configurations/_document_index_view_types.html.erb
+++ b/app/views/spotlight/search_configurations/_document_index_view_types.html.erb
@@ -1,4 +1,4 @@
-<%= f.form_group :document_index_view_types, label: {text: t(:'.document_index_view_types')} do %>
+<%= f.form_group :document_index_view_types, label: {text: t(:'.label')} do %>
   <%= f.fields_for :document_index_view_types, @blacklight_configuration.document_index_view_types_selected_hash do |vt| %>
     <% @blacklight_configuration.default_blacklight_config.view.select { |_k, v| v.if != false }.keys.each do |key| %>
       <%= vt.check_box key %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -156,6 +156,10 @@ en:
         home: "Home"
       header: "Curation"
     search_configurations:
+      document_index_view_types:
+        label: Result page types
+      default_per_page:
+        label: Default per page
       edit:
         header: "Search"
         tab:


### PR DESCRIPTION
Closes #1234 

Add strings for Curation > Search, Results tab labels

### Before
![before](https://cloud.githubusercontent.com/assets/101482/11282686/7a397506-8eb5-11e5-9c91-69a66b4819d3.png)

### After
![after](https://cloud.githubusercontent.com/assets/101482/11282734/ba911f8c-8eb5-11e5-9d95-c8b3a18b7348.png)
