### PR TITLE
Add a DefaultThumbnailJob and hook it up to Exhibit and Search

### DIFF
--- a/app/assets/stylesheets/spotlight/_browse.scss
+++ b/app/assets/stylesheets/spotlight/_browse.scss
@@ -25,13 +25,17 @@ $image-overlay-bottom-margin: $padding-large-vertical * 3;
   }
 
   .image-overlay {
-    img {width: 100%;}
-    position: relative;
+    border: 2px solid $gray-light;
+    border-radius: $border-radius-large;
     margin-bottom: $image-overlay-bottom-margin;
     max-height: 240px;
-    border-radius: $border-radius-large;
-    border: 2px solid $gray-light;
+    min-height: 140px;
     overflow: hidden;
+    position: relative;
+
+    img {
+      width: 100%;
+    }
   }
 
   .text-overlay {

--- a/app/jobs/spotlight/default_thumbnail_job.rb
+++ b/app/jobs/spotlight/default_thumbnail_job.rb
@@ -1,0 +1,14 @@
+module Spotlight
+  ###
+  # Calls the #set_default_thumbnail method
+  # on the object passed in and calls save
+  ###
+  class DefaultThumbnailJob < ActiveJob::Base
+    queue_as :default
+
+    def perform(thumbnailable)
+      thumbnailable.set_default_thumbnail
+      thumbnailable.save
+    end
+  end
+end

--- a/app/models/concerns/spotlight/default_thumbnailable.rb
+++ b/app/models/concerns/spotlight/default_thumbnailable.rb
@@ -1,0 +1,25 @@
+module Spotlight
+  ###
+  #  Simple concern to mixin to classes that
+  #  fetches a default thumbnail after creation
+  #  Classes that mixin this module should implement
+  #  a set_default_thumbnail method themselves
+  ###
+  module DefaultThumbnailable
+    extend ActiveSupport::Concern
+
+    included do
+      after_create(:fetch_default_thumb_later) if respond_to?(:after_create)
+    end
+
+    private
+
+    def fetch_default_thumb_later
+      DefaultThumbnailJob.perform_later(self)
+    end
+
+    def set_default_thumbnail
+      fail NotImplementedError
+    end
+  end
+end

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -49,6 +49,7 @@ module Spotlight
     after_create :initialize_config
     after_create :initialize_browse
     after_create :initialize_main_navigation
+    include Spotlight::DefaultThumbnailable
 
     scope :published, -> { where(published: true) }
 
@@ -83,6 +84,10 @@ module Spotlight
 
     def searchable?
       blacklight_config.search_fields.any? { |_k, v| v.enabled && v.include_in_simple_select != false }
+    end
+
+    def set_default_thumbnail
+      self.thumbnail ||= searches.first.try(:thumbnail)
     end
 
     protected

--- a/spec/jobs/spotlight/default_thumbnail_job_spec.rb
+++ b/spec/jobs/spotlight/default_thumbnail_job_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Spotlight::DefaultThumbnailJob do
+  let(:thumbnailable) { double('Thumbnailable') }
+  subject { described_class.new(thumbnailable) }
+
+  it 'calls #set_default_thumbnail on the object passed in and saves' do
+    expect(thumbnailable).to receive(:set_default_thumbnail)
+    expect(thumbnailable).to receive(:save)
+
+    subject.perform_now
+  end
+end

--- a/spec/models/spotlight/default_thumbnailable_concern_spec.rb
+++ b/spec/models/spotlight/default_thumbnailable_concern_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Spotlight::DefaultThumbnailable do
+  let(:test_class) { Class.new }
+  subject { test_class.new }
+  before { subject.extend(described_class) }
+
+  it 'invokes DefaultThumbnailJob job' do
+    expect(Spotlight::DefaultThumbnailJob).to receive(:perform_later).with(subject)
+    subject.send(:fetch_default_thumb_later)
+  end
+
+  it 'raises a NotImplementedError if the class does not have a set_default_thumbnail method' do
+    expect do
+      subject.send(:set_default_thumbnail)
+    end.to raise_error(NotImplementedError)
+  end
+end

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -47,6 +47,23 @@ describe Spotlight::Exhibit, type: :model do
     end
   end
 
+  context 'thumbnail' do
+    it 'calls DefaultThumbnailJob to fetch a default feature image' do
+      expect(Spotlight::DefaultThumbnailJob).to receive(:perform_later).with(subject.searches.first)
+      expect(Spotlight::DefaultThumbnailJob).to receive(:perform_later).with(subject)
+      subject.save!
+    end
+
+    context '#set_default_thumbnail' do
+      before { subject.save! }
+      it 'uses the thubmnail from the first search' do
+        subject.set_default_thumbnail
+        expect(subject.thumbnail).not_to be_nil
+        expect(subject.thumbnail).to eq subject.searches.first.thumbnail
+      end
+    end
+  end
+
   describe '#main_navigations' do
     subject { FactoryGirl.create(:exhibit, title: 'Sample') }
     it 'has main navigations' do

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -17,18 +17,27 @@ describe Spotlight::Search, type: :model do
 
   it { is_expected.to be_a Spotlight::Catalog::AccessControlsEnforcement }
 
-  it 'has a default feature image' do
-    allow(subject).to receive_messages(documents: [document])
-    subject.save!
-    expect(subject.thumbnail).not_to be_nil
-    expect(subject.thumbnail.image.path).to end_with 'default.jpg'
-  end
+  context 'thumbnail' do
+    it 'calls DefaultThumbnailJob to fetch a default feature image' do
+      expect(Spotlight::DefaultThumbnailJob).to receive(:perform_later).with(subject)
+      subject.save!
+    end
 
-  it 'uses a document with an image for the default feature image' do
-    allow(subject).to receive_messages(documents: [document_without_an_image, document])
-    subject.save!
-    expect(subject.thumbnail).not_to be_nil
-    expect(subject.thumbnail.image.path).to end_with 'default.jpg'
+    context '#set_default_thumbnail' do
+      it 'has a default feature image' do
+        allow(subject).to receive_messages(documents: [document])
+        subject.set_default_thumbnail
+        expect(subject.thumbnail).not_to be_nil
+        expect(subject.thumbnail.image.path).to end_with 'default.jpg'
+      end
+
+      it 'uses a document with an image for the default feature image' do
+        allow(subject).to receive_messages(documents: [document_without_an_image, document])
+        subject.set_default_thumbnail
+        expect(subject.thumbnail).not_to be_nil
+        expect(subject.thumbnail.image.path).to end_with 'default.jpg'
+      end
+    end
   end
 
   it 'has items' do


### PR DESCRIPTION
Closes #1004 
Closes #1225 

This adds a `DefaultThumbnailable` concern that is mixed into `Exhibit` and `Search`. This concern adds an `after_create` hook that fetches a default thumbnail asynchronously via the `ActiveJob` queue. Each class that mixes in the `DefaultThumbnailable` concern has to implement how it fetches the default thumbnail (by implementing a `set_default_thumbnail` method).

<img width="454" alt="browse-categories-w-no-thumb" src="https://cloud.githubusercontent.com/assets/96776/11315063/1842dda0-8fa1-11e5-8d16-373272e1341e.png">
