### PR TITLE
Add hound configuration for javascript and css styling

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,8 @@
 ruby:
   config_file: .rubocop.yml
+
+scss:
+  config_file: .scss-lint.yml
+
+javascript:
+  config_file: .javascript-style.json

--- a/.javascript-style.json
+++ b/.javascript-style.json
@@ -1,0 +1,10 @@
+{
+  "maxlen": 120,
+  "predef": [
+    "$",
+    "jQuery",
+    "Blacklight",
+    "Spotlight"
+  ]
+}
+

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,11 @@
+scss_files: 'app/assets/**/*.scss'
+
+exclude: 'vendor/**'
+
+linters:
+  SelectorDepth:
+    enabled: true
+    max_depth: 3
+
+  SelectorFormat:
+    enabled: false


### PR DESCRIPTION
- Disable CSS selector format style, as many of the elements we style are
  outside our immediate control. Fixes #1247.

- Update jshint configuration to require a line length of 120 (to match
  ruby-land equivalent; fixes #1246) and add predefined globals for Blacklight
  and Spotlight classes