### PR TITLE
Display a list of private exhibits on the exhibits index page

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -7,6 +7,7 @@ module Spotlight
     include Spotlight::ExhibitDocuments
 
     scope :published, -> { where(published: true) }
+    scope :unpublished, -> { where(published: false) }
 
     extend FriendlyId
     friendly_id :title, use: [:slugged, :finders]

--- a/app/views/spotlight/exhibits/_exhibit_list.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_list.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to exhibit.title, exhibit %>
+</li>

--- a/app/views/spotlight/exhibits/index.html.erb
+++ b/app/views/spotlight/exhibits/index.html.erb
@@ -10,6 +10,15 @@
     </div>
     <% end %>
   <% end %>
+
+  <% private_exhibits = @exhibits.unpublished.accessible_by(current_ability) %>
+
+  <% if private_exhibits.any? %>
+    <h2><%= t(:'.private') %></h2>
+    <ul>
+      <%= render collection: private_exhibits, partial: 'exhibit_list', as: 'exhibit' %>
+    </ul>
+  <% end %>
 </div>
 
 <aside class="col-md-3">

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -302,6 +302,8 @@ en:
           header: "Most popular pages"
     exhibits:
       breadcrumb: Home
+      index:
+        private: Private exhibits
       delete:
         heading: Delete exhibit
         warning_html: >

--- a/spec/views/spotlight/exhibits/index.html.erb_spec.rb
+++ b/spec/views/spotlight/exhibits/index.html.erb_spec.rb
@@ -3,10 +3,12 @@ require 'spec_helper'
 module Spotlight
   describe 'spotlight/exhibits/index', type: :view do
     let(:exhibits) { Spotlight::Exhibit.none }
+    let(:ability) { ::Ability.new(user) }
+    let(:user) { ::User.new }
 
     before do
       assign(:exhibits, exhibits)
-      allow(view).to receive_messages(exhibit_path: '/')
+      allow(view).to receive_messages(exhibit_path: '/', current_ability: ability)
     end
 
     context 'with published exhibits' do
@@ -23,6 +25,19 @@ module Spotlight
         expect(rendered).to have_text exhibit_a.title
         expect(rendered).to have_text exhibit_b.title
         expect(rendered).not_to have_text exhibit_c.title
+
+        expect(rendered).not_to include 'Private exhibits'
+      end
+
+      context 'with an authorized user' do
+        let(:user) { FactoryGirl.create(:site_admin) }
+
+        it 'includes a list of unpublished exhibits' do
+          render
+
+          expect(rendered).to include 'Private exhibits'
+          expect(rendered).to have_text exhibit_c.title
+        end
       end
     end
 


### PR DESCRIPTION
<img width="671" alt="screen shot 2015-11-23 at 8 11 54 am" src="https://cloud.githubusercontent.com/assets/111218/11342012/f95dbd04-91b9-11e5-8174-b64ea2a8cbd2.png">
