### PR TITLE
Guard against missing image files

### DIFF
--- a/app/serializers/spotlight/featured_image_representer.rb
+++ b/app/serializers/spotlight/featured_image_representer.rb
@@ -13,6 +13,8 @@ module Spotlight
     def image
       file = represented.image.file
 
+      return unless file
+
       { filename: file.filename, content_type: file.content_type, content: Base64.encode64(file.read) }
     end
 

--- a/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
+++ b/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
@@ -195,6 +195,18 @@ describe Spotlight::ExhibitExportSerializer do
         expect(subject.searches.first.thumbnail).not_to be_blank
         expect(subject.searches.first.thumbnail.image.file.path).not_to eq search.thumbnail.image.file.path
       end
+
+      context 'without an attached image' do
+        before do
+          search.masthead.remove_image!
+          search.masthead.save
+        end
+
+        it 'copies the masthead without an image' do
+          expect(subject.searches.last.masthead).not_to be_blank
+          expect(subject.searches.last.masthead.image).to be_blank
+        end
+      end
     end
 
     context 'with a masthead' do

--- a/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
+++ b/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
@@ -207,6 +207,20 @@ describe Spotlight::ExhibitExportSerializer do
           expect(subject.searches.last.masthead.image).to be_blank
         end
       end
+
+      context 'with a thumbnail from an uploaded resource' do
+        before do
+          search.masthead.document_global_id = SolrDocument.new(id: 'xyz').to_global_id
+          search.masthead.source = 'exhibit'
+          search.masthead.save
+
+          source_exhibit.reload
+        end
+
+        it 'copies the resource' do
+          expect(subject.searches.last.masthead).not_to be_blank
+        end
+      end
     end
 
     context 'with a masthead' do


### PR DESCRIPTION
For some (as yet undetermined) reason, we have some browse categories in the wild with mastheads without attached images. I suspect it's just migration pains, but it seems safe enough to guard against this case anyway.