### PR TITLE
Use the cropped exhibit thumbnail on the exhibits landing page

### DIFF
--- a/app/views/spotlight/exhibits/_exhibit_card.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card.html.erb
@@ -1,7 +1,7 @@
 <div class="col-xs-12 col-sm-4 exhibit-card">
   <div class="flipper">
     <div class="card-front card-face">
-      <%= image_tag(exhibit.thumbnail.image.url) if exhibit.thumbnail.present? %>
+      <%= image_tag(exhibit.thumbnail.image.cropped.url) if exhibit.thumbnail.present? %>
       <h2 class="card-title"><%= exhibit.title %></h2>
     </div>
     <div class="card-back card-face">


### PR DESCRIPTION
Fixes #1257

<img width="567" alt="screen shot 2015-11-23 at 11 31 28 am" src="https://cloud.githubusercontent.com/assets/111218/11347340/cedb0afc-91d5-11e5-97a4-26b37fcce111.png">
