### PR TITLE
Update message when editing browse categories while search is off

### DIFF
--- a/app/views/spotlight/searches/index.html.erb
+++ b/app/views/spotlight/searches/index.html.erb
@@ -2,19 +2,19 @@
 <div id="content" class="col-md-9">
   <%= curation_page_title %>
   <h3><%= header_with_count(t(:'.categories_header'), @searches.count) %></h3>
-  
+
   <% if @searches.empty? %>
     <%= t :'.no_saved_searches' %>
     <% unless @exhibit.searchable? %>
       <p class="instructions alert-warning">
-        <%= t(:'.not_searchable_html', href: link_to(t(:'spotlight.administration.sidebar.appearance'), spotlight.edit_exhibit_appearance_path(@exhibit))) %>
+        <%= t(:'.not_searchable_html', href: link_to(t(:'spotlight.curation.sidebar.search_configuration'), spotlight.edit_exhibit_search_configuration_path(@exhibit))) %>
       </p>
     <% end %>
   <% else %>
     <p class="instructions"><%= t(:'.instructions') %></p>
     <% unless @exhibit.searchable? %>
       <p class="instructions alert-warning">
-        <%= t(:'.not_searchable_html', href: link_to(t(:'spotlight.administration.sidebar.appearance'), spotlight.edit_exhibit_appearance_path(@exhibit))) %>
+        <%= t(:'.not_searchable_html', href: link_to(t(:'spotlight.curation.sidebar.search_configuration'), spotlight.edit_exhibit_search_configuration_path(@exhibit))) %>
       </p>
     <% end %>
     <%= bootstrap_form_for @exhibit, url: update_all_exhibit_searches_path(@exhibit), layout: :horizontal, control_col: 'col-sm-10' do |f| %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -485,8 +485,8 @@ en:
           which will be displayed here.
         not_searchable_html: >
           This exhibit is not currently searchable. To perform searches that can be saved as
-          additional browse categories, an Administrator must temporarily turn on the Searchable
-          option in the search configuration section of the Administration > %{href} page.
+          additional browse categories, temporarily turn on the Display search box
+          option in the Options section of the Curation > %{href} page.
       edit:
         header: "Edit Browse Category"
         title: "Curation - Browse"

--- a/spec/views/spotlight/searches/index.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/index.html.erb_spec.rb
@@ -25,9 +25,9 @@ describe 'spotlight/searches/index.html.erb', type: :view do
       render
       expect(rendered).to have_css '.alert-warning', text: %(\
 This exhibit is not currently searchable. To perform searches that can \
-be saved as additional browse categories, an Administrator must \
-temporarily turn on the Searchable option in the search configuration section \
-of the Administration > Appearance page.)
+be saved as additional browse categories, \
+temporarily turn on the Display search box option in the Options section \
+of the Curation > Search page.)
     end
   end
 end


### PR DESCRIPTION
Closes #1262 

Updated to:

![curation_-_curation_-_browse___exhibit_two_-_blacklight](https://cloud.githubusercontent.com/assets/101482/11374811/d890f4d2-928c-11e5-94b2-0df3ce32ce04.png)
