### PR TITLE
Update custom field names to not contain the field name

### DIFF
--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -192,14 +192,14 @@ module Spotlight
 
     def custom_index_fields
       Hash[exhibit.custom_fields.map do |x|
-        field = Blacklight::Configuration::IndexField.new x.configuration.merge(field: x.field)
+        field = Blacklight::Configuration::IndexField.new x.configuration.merge(key: x.field, field: x.solr_field)
         [x.field, field]
       end]
     end
 
     def custom_facet_fields
       Hash[exhibit.custom_fields.vocab.map do |x|
-        field = Blacklight::Configuration::FacetField.new x.configuration.merge(field: x.field, show: false)
+        field = Blacklight::Configuration::FacetField.new x.configuration.merge(key: x.field, field: x.solr_field, show: false)
         [x.field, field]
       end]
     end

--- a/app/models/spotlight/solr_document_sidecar.rb
+++ b/app/models/spotlight/solr_document_sidecar.rb
@@ -44,7 +44,16 @@ module Spotlight
     end
 
     def data_to_solr
-      data.except('configured_fields').merge(configured_fields_data_to_solr)
+      custom_fields_data_to_solr.merge(configured_fields_data_to_solr)
+    end
+
+    def custom_fields_data_to_solr
+      data.except('configured_fields').each_with_object({}) do |(key, value), solr_hash|
+        custom_field = custom_fields[key]
+        field_name = custom_field.solr_field if custom_field
+        field_name ||= key
+        solr_hash[field_name] = value
+      end
     end
 
     def configured_fields_data_to_solr
@@ -64,6 +73,12 @@ module Spotlight
 
     def upload_fields
       Spotlight::Resources::Upload.fields(exhibit)
+    end
+
+    def custom_fields
+      exhibit.custom_fields.each_with_object({}) do |custom_field, hash|
+        hash[custom_field.field] = custom_field
+      end
     end
   end
 end

--- a/db/migrate/20151124105543_update_custom_field_names.rb
+++ b/db/migrate/20151124105543_update_custom_field_names.rb
@@ -1,0 +1,31 @@
+class UpdateCustomFieldNames < ActiveRecord::Migration
+  def up
+    fields = {}
+
+    Spotlight::CustomField.find_each do |f|
+      f.update(field: f.send(:field_name))
+      fields[f.solr_field] = f
+    end
+
+    Spotlight::SolrDocumentSidecar.find_each do |f|
+      f.data.select { |k, v| fields.has_key? k }.each do |k, v|
+        f.data[fields[k].send(:field_name)] = f.data.delete(k)
+      end
+    end
+  end
+
+  def down
+    fields = {}
+
+    Spotlight::CustomField.find_each do |f|
+      fields[f.field] = f
+      f.update(field: f.send(:solr_field))
+    end
+
+    Spotlight::SolrDocumentSidecar.find_each do |f|
+      f.data.select { |k, v| fields.has_key? k }.each do |k, v|
+        f.data[fields[k].send(:solr_field)] = f.data.delete(k)
+      end
+    end
+  end
+end

--- a/spec/models/spotlight/resources/upload_spec.rb
+++ b/spec/models/spotlight/resources/upload_spec.rb
@@ -87,7 +87,7 @@ describe Spotlight::Resources::Upload, type: :model do
       expect(subject.to_solr[:spotlight_full_image_width_ssm]).to eq 800
     end
     it 'has fields representing exhibit specific custom fields' do
-      expect(subject.to_solr[custom_field.field]).to eq 'Custom Field Data'
+      expect(subject.to_solr[custom_field.solr_field]).to eq 'Custom Field Data'
     end
   end
 end


### PR DESCRIPTION
Instead, construct the solr field name with the exhibit prefix on-the-fly for solr.