### PR TITLE
Add a migration to reindex all solr documents

### DIFF
--- a/app/models/concerns/spotlight/solr_document/finder.rb
+++ b/app/models/concerns/spotlight/solr_document/finder.rb
@@ -17,6 +17,20 @@ module Spotlight
           @index ||= blacklight_config.repository_class.new(blacklight_config)
         end
 
+        def find_each
+          return to_enum(:find_each) unless block_given?
+
+          start = 0
+          search_params = { q: '*:*', fl: 'id', facet: false }
+          response = index.search(search_params.merge(start: start))
+
+          while response.documents.present?
+            response.documents.each { |x| yield x }
+            start += response.documents.length
+            response = index.search(search_params.merge(start: start))
+          end
+        end
+
         protected
 
         def blacklight_config

--- a/db/migrate/20151125090102_reindex_solr_documents.rb
+++ b/db/migrate/20151125090102_reindex_solr_documents.rb
@@ -1,0 +1,9 @@
+class ReindexSolrDocuments < ActiveRecord::Migration
+  def up
+    ::SolrDocument.find_each do |doc|
+      doc.reindex
+    end
+  rescue => e
+    say "Unable to reindex solr index: #{e}"
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -151,4 +151,18 @@ describe SolrDocument, type: :model do
       end
     end
   end
+
+  describe '.find_each' do
+    it 'enumerates the documents in the exhibit' do
+      expect(described_class.find_each).to be_a Enumerable
+    end
+
+    it 'pages through the index' do
+      allow_any_instance_of(Blacklight::Solr::Repository).to receive(:search).with(hash_including(start: 0)).and_return(double(documents: [1, 2, 3]))
+      allow_any_instance_of(Blacklight::Solr::Repository).to receive(:search).with(hash_including(start: 3)).and_return(double(documents: [4, 5, 6]))
+      allow_any_instance_of(Blacklight::Solr::Repository).to receive(:search).with(hash_including(start: 6)).and_return(double(documents: []))
+
+      expect(described_class.find_each.to_a).to match_array [1, 2, 3, 4, 5, 6]
+    end
+  end
 end


### PR DESCRIPTION
With the index changes in #1267 and #1269, we should reindex the exhibit-specific fields into solr when upgrading the application.