### PR TITLE
Update STI-based factories to lazily evaluate the class name to avoid 'Could not find table' errors with friendly_id

### DIFF
--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :feature_page, class: Spotlight::FeaturePage do
+  factory :feature_page, class: 'Spotlight::FeaturePage' do
     exhibit
     sequence(:title) { |n| "FeaturePage#{n}" }
     published true
@@ -13,14 +13,14 @@ FactoryGirl.define do
     content '[]'
     after(:build) { |subpage, evaluator| subpage.parent_page = FactoryGirl.create(:feature_page, exhibit: evaluator.exhibit) }
   end
-  factory :about_page, class: Spotlight::AboutPage do
+  factory :about_page, class: 'Spotlight::AboutPage' do
     exhibit
     sequence(:title) { |n| "AboutPage#{n}" }
     content '[]'
     published true
   end
 
-  factory :home_page, class: Spotlight::HomePage do
+  factory :home_page, class: 'Spotlight::HomePage' do
     exhibit
   end
 end


### PR DESCRIPTION
When initializing, friendly_id invokes some Rails logic that requires the database to be already migrated:
 
```
.gem/ruby/2.2.3/gems/activerecord-4.2.5/lib/active_record/connection_adapters/sqlite3_adapter.rb:511:in `table_structure': Could not find table 'spotlight_pages' (ActiveRecord::StatementInvalid)
	from .gem/ruby/2.2.3/gems/activerecord-4.2.5/lib/active_record/connection_adapters/sqlite3_adapter.rb:385:in `columns'
	from .gem/ruby/2.2.3/gems/activerecord-4.2.5/lib/active_record/connection_adapters/schema_cache.rb:43:in `columns'
	from .gem/ruby/2.2.3/gems/activerecord-4.2.5/lib/active_record/attributes.rb:93:in `columns'
	from .gem/ruby/2.2.3/gems/activerecord-4.2.5/lib/active_record/attributes.rb:98:in `columns_hash'
	from .gem/ruby/2.2.3/gems/activerecord-4.2.5/lib/active_record/inheritance.rb:73:in `descends_from_active_record?'
	from .gem/ruby/2.2.3/gems/activerecord-4.2.5/lib/active_record/inheritance.rb:79:in `finder_needs_type_condition?'
```

By deferring initialization for the STI-based + friendly_id enabled factories, we can avoid triggering this error.