### PR TITLE
Use the exhibit search builder to retrieve an exhibit's solr documents

### DIFF
--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -67,8 +67,6 @@ module Spotlight
         # Create a new config based on the defaults
         config = default_blacklight_config.inheritable_copy
 
-        config.search_builder_class.send(:include, Spotlight::Catalog::AccessControlsEnforcement::SearchBuilder)
-
         config.show.merge! show unless show.blank?
         config.index.merge! index unless index.blank?
 

--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -75,6 +75,16 @@ module Spotlight
       end
     end
 
+    def add_search_builder_mixin
+      if File.exist? 'app/models/search_builder.rb'
+        inject_into_file 'app/models/search_builder.rb', after: "include Blacklight::Solr::SearchBuilderBehavior\n" do
+          "\n  include Spotlight::Catalog::AccessControlsEnforcement::SearchBuilder\n"
+        end
+      else
+        say 'Unable to find SearchBuilder class; add `include Spotlight::Catalog::AccessControlsEnforcement::SearchBuilder` to the class manually.'
+      end
+    end
+
     def add_example_catalog_controller
       copy_file 'catalog_controller.rb', 'app/controllers/catalog_controller.rb'
     end

--- a/lib/spotlight/catalog/access_controls_enforcement.rb
+++ b/lib/spotlight/catalog/access_controls_enforcement.rb
@@ -12,6 +12,12 @@ module Spotlight
       ##
       # SearchBuilder mixin
       module SearchBuilder
+        extend ActiveSupport::Concern
+
+        included do
+          self.default_processor_chain += [:apply_permissive_visibility_filter, :apply_exhibit_resources_filter]
+        end
+
         def apply_permissive_visibility_filter(solr_params)
           return unless current_exhibit
           return if scope.respond_to?(:can?) && scope.can?(:curate, current_exhibit) && !blacklight_params[:public]

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -174,9 +174,11 @@ describe Spotlight::Exhibit, type: :model do
 
   describe '#solr_documents' do
     let(:blacklight_config) { Blacklight::Configuration.new }
+    let(:slug) { 'some_slug' }
 
     before do
       allow(subject).to receive(:blacklight_config).and_return(blacklight_config)
+      allow(subject).to receive(:slug).and_return(slug)
     end
 
     it 'enumerates the documents in the exhibit' do
@@ -184,7 +186,7 @@ describe Spotlight::Exhibit, type: :model do
     end
 
     it 'pages through the index' do
-      allow_any_instance_of(Blacklight::Solr::Repository).to receive(:search).with(hash_including(start: 0)).and_return(double(documents: [1, 2, 3]))
+      allow_any_instance_of(Blacklight::Solr::Repository).to receive(:search).and_return(double(documents: [1, 2, 3]))
       allow_any_instance_of(Blacklight::Solr::Repository).to receive(:search).with(hash_including(start: 3)).and_return(double(documents: [4, 5, 6]))
       allow_any_instance_of(Blacklight::Solr::Repository).to receive(:search).with(hash_including(start: 6)).and_return(double(documents: []))
 
@@ -197,7 +199,8 @@ describe Spotlight::Exhibit, type: :model do
       end
 
       it 'filters the solr results using the exhibit filter' do
-        allow_any_instance_of(Blacklight::Solr::Repository).to receive(:search).with(hash_including(fq: [subject.solr_data])).and_return(double(documents: []))
+        expected_query_params = { fq: ["spotlight_exhibit_slug_#{subject.slug}_bsi:true"] }
+        allow_any_instance_of(Blacklight::Solr::Repository).to receive(:search).with(hash_including(expected_query_params)).and_return(double(documents: []))
         expect(subject.solr_documents.to_a).to be_blank
       end
     end


### PR DESCRIPTION
Instead of using custom logic for picking out all the exhibit's solr documents, use the application's `SearchBuilder` class, which already has that logic.