### PR TITLE
Add spotlight:export rake task for exporting an exhibit as JSON

### DIFF
--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -52,6 +52,13 @@ namespace :spotlight do
     puts Spotlight::ExhibitExportSerializer.new(exhibit.reload).to_json
   end
 
+  desc 'Export an exhibit as JSON'
+  task :export, [:exhibit_slug] => :environment do |_, args|
+    exhibit = Spotlight::Exhibit.find_by(slug: args[:exhibit_slug])
+
+    puts Spotlight::ExhibitExportSerializer.new(exhibit).to_json
+  end
+
   def prompt_to_create_user
     User.find_or_create_by!(email: prompt_for_email) do |u|
       puts 'User not found. Enter a password to create the user.'

--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -30,7 +30,7 @@ namespace :spotlight do
   end
 
   desc 'Import an exhibit'
-  task import: :environment do
+  task :import, [:exhibit_slug] => :environment do |_, args|
     contents = if ENV['FILE']
                  File.read(ENV['FILE'])
                else
@@ -39,7 +39,9 @@ namespace :spotlight do
 
     data = JSON.parse(contents)
 
-    exhibit = Spotlight::Exhibit.find_or_create_by! slug: data['slug'] do |e|
+    slug = args[:exhibit_slug] || data['slug']
+
+    exhibit = Spotlight::Exhibit.find_or_create_by! slug: slug do |e|
       e.title = data['title']
     end
 


### PR DESCRIPTION
Support a better exhibit import/export experience from the command line by adding the `spotlight:export` rake task, and updating `spotlight:import` to accept a slug as an argument to the task.