### PR TITLE
Change the search field selector to use a smaller font size, so it aligns better with the query input

### DIFF
--- a/app/assets/stylesheets/spotlight/_blacklight_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_blacklight_overrides.scss
@@ -20,5 +20,6 @@
   .search_field {
     background: transparent;
     border: none;
+    font-size: $font-size-small;
   }
 }


### PR DESCRIPTION
Before:

<img width="399" alt="screen shot 2015-12-02 at 2 31 04 pm" src="https://cloud.githubusercontent.com/assets/111218/11546317/5ea4e950-9901-11e5-8346-f10eb549434e.png">

After:

<img width="378" alt="screen shot 2015-12-02 at 2 30 59 pm" src="https://cloud.githubusercontent.com/assets/111218/11546319/6122a564-9901-11e5-8d6e-fe6c5248c29e.png">
