### PR TITLE
Text updates in Admin > Configuration pages

### DIFF
--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -308,7 +308,7 @@ en:
           This action is irreversible. Be sure to back up the exhibit settings and content using
           the %{export_link} feature before proceeding.
       edit:
-        header: Settings
+        header: General
         basic_settings:
           heading: Basic settings
       form:

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -218,8 +218,8 @@ en:
           show: "Item Details"
         instructions: >
           Select metadata fields to display on each type of page. Click a field name
-          to edit its display label. Drag and drop fields to specify the order they
-          are displayed on the Item Details page.
+          to edit its display label. Drag and drop fields to specify the order in which they
+          are displayed.
     catalog:
       breadcrumb:
         index: 'Search Results'


### PR DESCRIPTION
Fixing a couple of minor problems I noticed when updating the wiki pages (arrows point to out of date text):

Before
--
![configuration_-_settings___exhibit_one_-_blacklight](https://cloud.githubusercontent.com/assets/101482/11550202/2bd7d05c-9922-11e5-8235-e647f0bc7f50.png)

After
-- 
![configuration_-_general___exhibit_one_-_blacklight](https://cloud.githubusercontent.com/assets/101482/11550239/757966e4-9922-11e5-9cab-4dba9b4b558e.png)


Before
--
![configuration_-_metadata___exhibit_one_-_blacklight](https://cloud.githubusercontent.com/assets/101482/11550218/4a869b1e-9922-11e5-9020-b2162efd3018.png)


After
--
<img width="893" alt="configuration_-_metadata___exhibit_one_-_blacklight copy" src="https://cloud.githubusercontent.com/assets/101482/11550242/7c4f70bc-9922-11e5-8a54-fd59ba4b8384.png">

