### PR TITLE
The site thumbnail should be a square image by default

### DIFF
--- a/app/helpers/spotlight/jcrop_helper.rb
+++ b/app/helpers/spotlight/jcrop_helper.rb
@@ -15,15 +15,23 @@ module Spotlight
     end
 
     def default_thumbnail_jcrop_options
+      w, h = Spotlight::Engine.config.featured_image_thumb_size
+
       {
         croppable: true,
         selector: 'featuredimage_image',
         bg_color: 'black',
         bg_opacity: '.4',
         box_width: '600',
-        aspect_ratio: 4.0 / 3.0,
+        aspect_ratio: w.to_f / h.to_f,
         initial_set_select: '[0, 0, 100000, 100000]'
       }
+    end
+
+    def default_site_thumbnail_jcrop_options
+      w, h = Spotlight::Engine.config.featured_image_square_size
+
+      default_thumbnail_jcrop_options.merge(aspect_ratio: w.to_f / h.to_f)
     end
   end
 end

--- a/app/uploaders/spotlight/featured_image_uploader.rb
+++ b/app/uploaders/spotlight/featured_image_uploader.rb
@@ -11,7 +11,11 @@ module Spotlight
     end
 
     version :thumb, from_version: :cropped do
-      process resize_to_fill: [400, 300]
+      process resize_to_fill: Spotlight::Engine.config.featured_image_thumb_size
+    end
+
+    version :square, from_version: :cropped do
+      process resize_to_fill: Spotlight::Engine.config.featured_image_square_size
     end
 
     def store_dir

--- a/app/views/spotlight/appearances/edit.html.erb
+++ b/app/views/spotlight/appearances/edit.html.erb
@@ -39,7 +39,7 @@
       <div role="tabpanel" class="tab-pane" id="site-thumbnail">
         <p class="instructions"><%= t(:'.site_thumbnail.help') %></p>
         <%= f.fields_for(:thumbnail, current_exhibit.thumbnail || current_exhibit.build_thumbnail) do |m| %>
-          <%= render '/spotlight/featured_images/form', f: m, jcrop_options: default_thumbnail_jcrop_options %>
+          <%= render '/spotlight/featured_images/form', f: m, jcrop_options: default_site_thumbnail_jcrop_options %>
         <% end %>
       </div>
 

--- a/app/views/spotlight/exhibits/_exhibit_card.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card.html.erb
@@ -1,7 +1,7 @@
 <div class="col-xs-12 col-sm-4 exhibit-card">
   <div class="flipper">
     <div class="card-front card-face">
-      <%= image_tag(exhibit.thumbnail.image.cropped.url) if exhibit.thumbnail.present? %>
+      <%= image_tag(exhibit.thumbnail.image.square.url) if exhibit.thumbnail.present? %>
       <h2 class="card-title"><%= exhibit.title %></h2>
     </div>
     <div class="card-back card-face">

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -91,6 +91,8 @@ module Spotlight
 
     # Configure the CarrierWave file storage mechanism
     Spotlight::Engine.config.uploader_storage = :file
+    Spotlight::Engine.config.featured_image_thumb_size = [400, 300]
+    Spotlight::Engine.config.featured_image_square_size = [400, 400]
 
     initializer 'spotlight-assets.initialize' do
       Rails.application.config.assets.precompile += %w( Jcrop.gif )

--- a/spec/helpers/spotlight/jcrop_helper_spec.rb
+++ b/spec/helpers/spotlight/jcrop_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Spotlight::JcropHelper do
+  describe '.default_thumbnail_jcrop_options' do
+    it 'produces a 4:3 aspect ratio by default' do
+      expect(helper.default_thumbnail_jcrop_options[:aspect_ratio]).to eq 4.0 / 3.0
+    end
+
+    context 'with a custom thumbnail size' do
+      before do
+        allow(Spotlight::Engine.config).to receive(:featured_image_thumb_size).and_return([7, 5])
+      end
+
+      it 'produces a 7:5 aspect ratio' do
+        expect(helper.default_thumbnail_jcrop_options[:aspect_ratio]).to eq 7.0 / 5.0
+      end
+    end
+  end
+
+  describe '.default_site_thumbnail_jcrop_options' do
+    it 'produces a 1:1 aspect ratio by default' do
+      expect(helper.default_site_thumbnail_jcrop_options[:aspect_ratio]).to eq 1
+    end
+
+    context 'with a custom square thumbnail size' do
+      before do
+        allow(Spotlight::Engine.config).to receive(:featured_image_square_size).and_return([3, 2])
+      end
+
+      it 'produces a 3:2 aspect ratio' do
+        expect(helper.default_site_thumbnail_jcrop_options[:aspect_ratio]).to eq 3.0 / 2.0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Generated thumbnails should also be a configurable size.

Fixes #1295 

<img width="515" alt="screen shot 2015-12-04 at 8 07 57 am" src="https://cloud.githubusercontent.com/assets/111218/11594544/75347e24-9a5f-11e5-9021-3ab46ab5c67f.png">
