### PR TITLE
Only change the slug for a page, search, etc when the title changes; …

### DIFF
--- a/app/models/spotlight/contact.rb
+++ b/app/models/spotlight/contact.rb
@@ -42,7 +42,7 @@ module Spotlight
     protected
 
     def should_generate_new_friendly_id?
-      name_changed?
+      super || (name_changed? && persisted?)
     end
   end
 end

--- a/app/models/spotlight/custom_field.rb
+++ b/app/models/spotlight/custom_field.rb
@@ -102,7 +102,7 @@ module Spotlight
     end
 
     def should_generate_new_friendly_id?
-      true
+      super || persisted?
     end
 
     # Try building a slug based on the following fields in

--- a/app/models/spotlight/page.rb
+++ b/app/models/spotlight/page.rb
@@ -76,7 +76,7 @@ module Spotlight
     end
 
     def should_generate_new_friendly_id?
-      title_changed?
+      super || (title_changed? && persisted?)
     end
 
     def should_display_title?

--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -88,7 +88,7 @@ module Spotlight
     end
 
     def should_generate_new_friendly_id?
-      title_changed?
+      super || (title_changed? && persisted?)
     end
 
     alias_method :current_exhibit, :exhibit

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -77,7 +77,7 @@ describe 'Home page', type: :feature do
       exhibit.home_page.save
     end
     it 'does not display the facet sidebar' do
-      visit spotlight.exhibit_home_page_path(exhibit.home_page)
+      visit spotlight.exhibit_home_page_path(exhibit)
       expect(page).not_to have_css('#sidebar')
     end
   end

--- a/spec/models/spotlight/page_spec.rb
+++ b/spec/models/spotlight/page_spec.rb
@@ -74,4 +74,25 @@ describe Spotlight::Page, type: :model do
       expect(page).to have_content
     end
   end
+
+  describe '#slug' do
+    let(:page) { FactoryGirl.create(:feature_page) }
+
+    it 'gets a default slug' do
+      expect(page.slug).not_to be_blank
+    end
+
+    it 'is updated when the title changes' do
+      page.update(title: 'abc')
+      expect(page.slug).to eq 'abc'
+    end
+
+    context 'with a custom slug' do
+      let(:page) { FactoryGirl.create(:feature_page, slug: 'xyz') }
+
+      it 'gets a default slug' do
+        expect(page.slug).to eq 'xyz'
+      end
+    end
+  end
 end

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -58,4 +58,25 @@ describe Spotlight::Search, type: :model do
       expect(described_class.published.map(&:weight)).to eq [1, 5, 10]
     end
   end
+
+  describe '#slug' do
+    let(:search) { FactoryGirl.create(:search) }
+
+    it 'gets a default slug' do
+      expect(search.slug).not_to be_blank
+    end
+
+    it 'is updated when the title changes' do
+      search.update(title: 'abc')
+      expect(search.slug).to eq 'abc'
+    end
+
+    context 'with a custom slug' do
+      let(:search) { FactoryGirl.create(:search, slug: 'xyz') }
+
+      it 'gets a default slug' do
+        expect(search.slug).to eq 'xyz'
+      end
+    end
+  end
 end

--- a/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
+++ b/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
@@ -176,6 +176,14 @@ describe Spotlight::ExhibitExportSerializer do
       expect(subject.feature_pages.first.child_pages.length).to eq 1
     end
 
+    context 'page slugs' do
+      let!(:feature_page) { FactoryGirl.create(:feature_page, exhibit: source_exhibit, slug: 'xyz') }
+
+      it 'uses the existing slug for the page' do
+        expect(subject.feature_pages.find('xyz')).to be_persisted
+      end
+    end
+
     context 'with a feature page' do
       let(:feature_page) { FactoryGirl.create(:feature_page, exhibit: source_exhibit) }
       let(:thumbnail) { FactoryGirl.create(:featured_image) }


### PR DESCRIPTION
…if a slug was provided at creation, use it.