### PR TITLE
Use a darker background for the page-level masthead

### DIFF
--- a/app/assets/stylesheets/spotlight/_header.scss
+++ b/app/assets/stylesheets/spotlight/_header.scss
@@ -41,6 +41,7 @@ $masthead-image-blur: 1px;
 
   &.page-masthead {
     @include transparent-masthead-navigation-menu();
+    background-color: $navbar-transparent-page-bg;
     border-bottom: 1px solid $navbar-transparent-border;
     margin-bottom: 0;
     margin-top: 0;

--- a/app/assets/stylesheets/spotlight/_variables.scss
+++ b/app/assets/stylesheets/spotlight/_variables.scss
@@ -21,6 +21,8 @@ $navbar-transparent-link-active-bg: rgba(255, 255, 255, 0.3) !default;
 $navbar-transparent-link-disabled-color: #ccc !default;
 $navbar-transparent-link-disabled-bg: transparent !default;
 
+$navbar-transparent-page-bg: rgba(0, 0, 0, 0.5) !default;
+
 // Navbar brand label
 $navbar-transparent-brand-color: $navbar-transparent-link-color !default;
 $navbar-transparent-brand-hover-color: darken($navbar-transparent-brand-color, 10%) !default;


### PR DESCRIPTION
(Fixing a regression in #1304)

Before:
<img width="614" alt="screen shot 2015-12-08 at 7 24 50 am" src="https://cloud.githubusercontent.com/assets/111218/11659393/f0bd938a-9d7c-11e5-91b9-ef3b422055b2.png">

After:
<img width="724" alt="screen shot 2015-12-08 at 7 24 41 am" src="https://cloud.githubusercontent.com/assets/111218/11659400/f558ec14-9d7c-11e5-9b2f-a2a52e3fa03a.png">
