### PR TITLE
postgres does not support blob field type

### DIFF
--- a/db/migrate/20151110082345_add_metadata_to_spotlight_resource.rb
+++ b/db/migrate/20151110082345_add_metadata_to_spotlight_resource.rb
@@ -1,5 +1,12 @@
 class AddMetadataToSpotlightResource < ActiveRecord::Migration
   def up
-    add_column :spotlight_resources, :metadata, :blob
+    # postgresql does not have a blob type
+    conn_type = connection.adapter_name.downcase.to_sym
+    field_type = (conn_type == :postgresql) ? :bytea : :blob
+    add_column :spotlight_resources, :metadata, field_type
+  end
+
+  def down
+    remove_column :spotlight_resources, :metadata
   end
 end


### PR DESCRIPTION
Postgres doesn't have a blob type, thus this migration breaks when install Spotlight in an existing Rails app using Postgres. This fixes that issue and adds the previously missing rollback task. 