### PR TITLE
Remove database-level locking when reindexing resources

### DIFF
--- a/app/models/spotlight/resource.rb
+++ b/app/models/spotlight/resource.rb
@@ -18,7 +18,6 @@ module Spotlight
       :last_index_elapsed_time,
       :last_indexed_finished], coder: JSON
 
-    around_index :reindex_with_lock
     around_index :reindex_with_logging
     after_index :commit
 
@@ -133,12 +132,6 @@ module Spotlight
       end
 
       protected
-
-      def reindex_with_lock
-        with_lock do
-          yield
-        end
-      end
 
       def reindex_with_logging
         time_start = Time.zone.now


### PR DESCRIPTION
This doesn't seem to scale well for very large collections, and with all
indexing happening through ActiveJob queuing also seems unnecessary.