### PR TITLE
Refactor Spotlight::Search to remove Blacklight::SearchHelper mixin; …

### DIFF
--- a/app/views/spotlight/browse/_search.html.erb
+++ b/app/views/spotlight/browse/_search.html.erb
@@ -1,4 +1,4 @@
-<%= cache [@exhibit, search, search.count] do %>
+<%= cache [@exhibit, search, search.documents.size] do %>
   <div class="col-sm-4 col-xs-12 category">
     <%= link_to spotlight.exhibit_browse_path(@exhibit, search) do %>
       <div class="image-overlay">
@@ -6,7 +6,7 @@
         <div class="text-overlay">
            <h2 class="browse-category-title">
              <%= search.title%>
-             <small><%= t :'spotlight.browse.search.item_count', count: search.count %></small>
+             <small><%= t :'spotlight.browse.search.item_count', count: search.documents.size %></small>
            </h2>
          </div>
       </div>

--- a/app/views/spotlight/browse/_search_title.html.erb
+++ b/app/views/spotlight/browse/_search_title.html.erb
@@ -1,2 +1,2 @@
 <h1><%= search.title %></h1>
-<small class="item-count"><%= t :'spotlight.browse.search.item_count', count: search.count %></small>
+<small class="item-count"><%= t :'spotlight.browse.search.item_count', count: search.documents.size %></small>

--- a/app/views/spotlight/searches/_search.html.erb
+++ b/app/views/spotlight/searches/_search.html.erb
@@ -8,7 +8,7 @@
       <div class="pic thumbnail"><%= image_tag(search.thumbnail.image.thumb) if search.thumbnail %></div>
       <div class="main">
         <div class="title panel-title"><%= search.title %></div>
-        <div class="count"><%= t :'.item_count', count: search.count %></div>
+        <div class="count"><%= t :'.item_count', count: search.documents.size %></div>
         <div class="actions"><%= exhibit_view_link(search) %> &bull; <%= exhibit_edit_link(search) %> &bull; <%= exhibit_delete_link(search) %></div>
         <%= f.hidden_field :id %>
         <%= f.hidden_field :weight, data: {property: "weight"} %>

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -44,7 +44,7 @@ describe Spotlight::Search, type: :model do
     let(:query_params) { {} }
 
     it 'has items' do
-      expect(subject.count).to eq 55
+      expect(subject.documents.size).to eq 55
     end
 
     it 'has images' do

--- a/spec/views/spotlight/browse/_search.html.erb_spec.rb
+++ b/spec/views/spotlight/browse/_search.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe 'spotlight/browse/search', type: :view do
   let(:search) { FactoryGirl.create(:search) }
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   before :each do
-    allow(search).to receive_messages(count: 15)
+    allow(search).to receive_messages(documents: double(size: 15))
     allow(search).to receive_message_chain(:thumbnail, :image, thumb: '/some/image')
   end
 
@@ -24,6 +24,6 @@ describe 'spotlight/browse/search', type: :view do
 
   it 'displays the item count' do
     render partial: 'spotlight/browse/search', locals: { search: search }
-    expect(response).to have_selector 'small', text: /#{search.count} items/i
+    expect(response).to have_selector 'small', text: /#{search.documents.size} items/i
   end
 end

--- a/spec/views/spotlight/browse/show.html.erb_spec.rb
+++ b/spec/views/spotlight/browse/show.html.erb_spec.rb
@@ -8,7 +8,7 @@ describe 'spotlight/browse/show', type: :view do
     allow(view).to receive_messages(exhibit_masthead?: true)
     allow(view).to receive_messages(blacklight_config: Blacklight::Configuration.new)
     view.blacklight_config.view.gallery = true
-    allow(search).to receive_messages(count: 15)
+    allow(search).to receive_messages(documents: double(size: 15))
     allow(view).to receive_messages(render_document_index_with_view: '')
     stub_template('_results_pagination.html.erb' => '')
     stub_template('_sort_and_per_page.html.erb' => 'Sort and Per Page actions')
@@ -23,14 +23,14 @@ describe 'spotlight/browse/show', type: :view do
   it 'has a heading and item count when there is no current search masthead' do
     render
     expect(response).to have_selector 'h1', text: search.title
-    expect(response).to have_selector '.item-count', text: "#{search.count} items"
+    expect(response).to have_selector '.item-count', text: "#{search.documents.size} items"
   end
 
   it 'does not have the heading and item count when there is a current search masthead' do
     allow(view).to receive_messages(exhibit_masthead?: false)
     render
     expect(response).to_not have_selector 'h1', text: search.title
-    expect(response).to_not have_selector '.item-count', text: "#{search.count} items"
+    expect(response).to_not have_selector '.item-count', text: "#{search.documents.size} items"
   end
 
   it 'has an edit button' do


### PR DESCRIPTION
…instead, build the SearchBuilder instance locally