### PR TITLE
Add role-based filtering for exhibits displayed on the exhibits index

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -41,6 +41,7 @@
   @extend .text-center;
 
   font-size: $font-size-h4;
+  line-height: 1.2;
 }
 
 .card-front {
@@ -54,15 +55,22 @@
   }
 
   .card-title {
+    padding-left: $padding-small-horizontal;
+    padding-right: $padding-small-horizontal;
     padding-top: $padding-large-vertical;
   }
 
   .unpublished {
     @extend .center-block;
 
+    font-size: $font-size-base;
     margin-top: -1em;
     position: relative;
     width: 15ch;
+  }
+
+  .unpublished + .card-title {
+    padding-top: 0;
   }
 }
 

--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -67,10 +67,10 @@
     margin-top: -1em;
     position: relative;
     width: 15ch;
-  }
 
-  .unpublished + .card-title {
-    padding-top: 0;
+    + .card-title {
+      padding-top: 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -56,6 +56,14 @@
   .card-title {
     padding-top: $padding-large-vertical;
   }
+
+  .unpublished {
+    @extend .center-block;
+
+    margin-top: -1em;
+    position: relative;
+    width: 15ch;
+  }
 }
 
 .card-back {

--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -32,6 +32,7 @@ module Spotlight
       @exhibit.attributes = exhibit_params
 
       if @exhibit.save
+        @exhibit.roles.create user: current_user, role: 'admin' if current_user
         redirect_to spotlight.exhibit_dashboard_path(@exhibit), notice: t(:'helpers.submit.exhibit.created', model: @exhibit.class.model_name.human.downcase)
       else
         render action: :new

--- a/app/models/concerns/spotlight/user.rb
+++ b/app/models/concerns/spotlight/user.rb
@@ -5,6 +5,7 @@ module Spotlight
     extend ActiveSupport::Concern
     included do
       has_many :roles, class_name: 'Spotlight::Role', dependent: :destroy
+      has_many :exhibits, class_name: 'Spotlight::Exhibit', through: :roles
 
       before_create :add_default_roles
     end

--- a/app/views/spotlight/exhibits/_exhibit_card.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card.html.erb
@@ -2,6 +2,9 @@
   <div class="flipper">
     <div class="card-front card-face">
       <%= image_tag(exhibit.thumbnail.image.square.url) if exhibit.thumbnail.present? %>
+      <% unless exhibit.published? %>
+        <div class="label label-warning unpublished"><%= t('.unpublished') %></div>
+      <% end %>
       <h2 class="card-title"><%= exhibit.title %></h2>
     </div>
     <div class="card-back card-face">

--- a/app/views/spotlight/exhibits/_exhibit_list.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_list.html.erb
@@ -1,3 +1,0 @@
-<li>
-  <%= link_to exhibit.title, exhibit %>
-</li>

--- a/app/views/spotlight/exhibits/index.html.erb
+++ b/app/views/spotlight/exhibits/index.html.erb
@@ -1,24 +1,49 @@
 <div class="col-md-9">
-  <% if @exhibits.published.none? %>
-    <%= render 'missing_exhibits' %>
-  <% end %>
-
-  <%= cache cache_key_for_spotlight_exhibits do %>
-    <% @exhibits.published.each_slice(3).each do |row| %>
-    <div class="row"><!-- start main content row -->
-      <%= render collection: row, partial: 'exhibit_card', as: 'exhibit' %>
-    </div>
-    <% end %>
-  <% end %>
-
-  <% private_exhibits = @exhibits.unpublished.accessible_by(current_ability) %>
-
-  <% if private_exhibits.any? %>
-    <h2><%= t(:'.private') %></h2>
-    <ul>
-      <%= render collection: private_exhibits, partial: 'exhibit_list', as: 'exhibit' %>
+  <% if (current_user && current_user.exhibits.any?) || can?(:manage, Spotlight::Exhibit) %>
+    <ul class="nav nav-tabs" role="tablist">
+      <li role="presentation" class="active"><a href="#published" aria-controls="published" role="tab" data-toggle="tab"><%= t('.published') %></a></li>
+      <li role="presentation"><a href="#user" aria-controls="user" role="tab" data-toggle="tab"><%= t('.user') %></a></li>
+      <% if can?(:manage, Spotlight::Exhibit) %>
+        <li role="presentation"><a href="#unpublished" aria-controls="unpublished" role="tab" data-toggle="tab"><%= t('.unpublished') %></a></li>
+      <% end %>
     </ul>
   <% end %>
+
+  <div class="tab-content">
+    <div role="tabpanel" class="tab-pane active" id="published">
+      <% if @exhibits.published.none? %>
+        <%= render 'missing_exhibits' %>
+      <% end %>
+
+      <%= cache cache_key_for_spotlight_exhibits do %>
+        <% @exhibits.published.each_slice(3).each do |row| %>
+        <div class="row"><!-- start main content row -->
+          <%= render collection: row, partial: 'exhibit_card', as: 'exhibit' %>
+        </div>
+        <% end %>
+      <% end %>
+    </div>
+
+    <% if current_user && current_user.exhibits.any? %>
+      <div role="tabpanel" class="tab-pane" id="user">
+        <% current_user.exhibits.each_slice(3).each do |row| %>
+          <div class="row"><!-- start main content row -->
+            <%= render collection: row, partial: 'exhibit_card', as: 'exhibit' %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if @exhibits.unpublished.accessible_by(current_ability).any? %>
+      <div role="tabpanel" class="tab-pane" id="unpublished">
+        <% @exhibits.unpublished.accessible_by(current_ability).each_slice(3).each do |row| %>
+          <div class="row"><!-- start main content row -->
+            <%= render collection: row, partial: 'exhibit_card', as: 'exhibit' %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
 </div>
 
 <aside class="col-md-3">

--- a/app/views/spotlight/exhibits/index.html.erb
+++ b/app/views/spotlight/exhibits/index.html.erb
@@ -2,10 +2,10 @@
   <% if (current_user && current_user.exhibits.any?) || can?(:manage, Spotlight::Exhibit) %>
     <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a href="#published" aria-controls="published" role="tab" data-toggle="tab"><%= t('.published') %></a></li>
-      <li role="presentation"><a href="#user" aria-controls="user" role="tab" data-toggle="tab"><%= t('.user') %></a></li>
       <% if can?(:manage, Spotlight::Exhibit) %>
         <li role="presentation"><a href="#unpublished" aria-controls="unpublished" role="tab" data-toggle="tab"><%= t('.unpublished') %></a></li>
       <% end %>
+      <li role="presentation"><a href="#user" aria-controls="user" role="tab" data-toggle="tab"><%= t('.user') %></a></li>
     </ul>
   <% end %>
 
@@ -24,9 +24,9 @@
       <% end %>
     </div>
 
-    <% if current_user && current_user.exhibits.any? %>
-      <div role="tabpanel" class="tab-pane" id="user">
-        <% current_user.exhibits.each_slice(3).each do |row| %>
+    <% if @exhibits.unpublished.accessible_by(current_ability).any? %>
+      <div role="tabpanel" class="tab-pane" id="unpublished">
+        <% @exhibits.unpublished.accessible_by(current_ability).each_slice(3).each do |row| %>
           <div class="row"><!-- start main content row -->
             <%= render collection: row, partial: 'exhibit_card', as: 'exhibit' %>
           </div>
@@ -34,9 +34,9 @@
       </div>
     <% end %>
 
-    <% if @exhibits.unpublished.accessible_by(current_ability).any? %>
-      <div role="tabpanel" class="tab-pane" id="unpublished">
-        <% @exhibits.unpublished.accessible_by(current_ability).each_slice(3).each do |row| %>
+    <% if current_user && current_user.exhibits.any? %>
+      <div role="tabpanel" class="tab-pane" id="user">
+        <% current_user.exhibits.each_slice(3).each do |row| %>
           <div class="row"><!-- start main content row -->
             <%= render collection: row, partial: 'exhibit_card', as: 'exhibit' %>
           </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -311,7 +311,9 @@ en:
     exhibits:
       breadcrumb: Home
       index:
-        private: Private exhibits
+        published: Published exhibits
+        user: Your exhibits
+        unpublished: Unpublished exhibits
       delete:
         heading: Delete exhibit
         warning_html: >
@@ -337,6 +339,7 @@ en:
             label: URL slug
             help_block: A hyphenated name to be displayed in the URL for the exhibit (e.g., "maps-of-africa").
       exhibit_card:
+        unpublished: Unpublished
         visit_exhibit: "Visit exhibit"
       new:
         header: Create a new exhibit

--- a/spec/controllers/spotlight/exhibits_controller_spec.rb
+++ b/spec/controllers/spotlight/exhibits_controller_spec.rb
@@ -91,6 +91,8 @@ describe Spotlight::ExhibitsController, type: :controller do
 
         expect(exhibit.title).to eq 'Some Title'
         expect(exhibit.slug).to eq 'custom-slug'
+
+        expect(user.exhibits).to include exhibit
       end
     end
   end


### PR DESCRIPTION
Fixes #1324

<img width="831" alt="screen shot 2015-12-11 at 2 28 18 pm" src="https://cloud.githubusercontent.com/assets/111218/11757210/68515b68-a014-11e5-8a6b-3cdebc545b31.png">
<img width="1108" alt="screen shot 2015-12-11 at 2 28 11 pm" src="https://cloud.githubusercontent.com/assets/111218/11757211/68529730-a014-11e5-8d31-e1dbc99b629d.png">
<img width="776" alt="screen shot 2015-12-11 at 2 36 46 pm" src="https://cloud.githubusercontent.com/assets/111218/11757238/a0c10f70-a014-11e5-9adc-387af3e7b186.png">

