### PR TITLE
Use the flash_messages partial in the standard way

### DIFF
--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -37,7 +37,7 @@
   <%= render partial: 'shared/ajax_modal' %>
 
   <div id="main-container" class="container">
-    <%= render partial: 'shared/flash_messages' %>
+    <%= render partial: '/flash_msg', layout: 'shared/flash_messages' %>
 
     <div class="row">
       <%= content_for?(:content) ? yield(:content) : yield %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,7 +1,0 @@
-<div class="row">
-  <div class="col-md-12">
-    <div id="main-flashes">
-      <%= render :partial=>'/flash_msg' %>
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
This enables a Blacklight application which renders
shared/flash_messages to mount Spotlight

See https://github.com/projectblacklight/blacklight/blob/39634587ed3bde2eced6d94673417c78eb2f4682/app/views/layouts/blacklight.html.erb#L41 as an example of the "standard" way