### PR TITLE
Make the exhibit filter configurable

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -74,7 +74,7 @@ module Spotlight
     end
 
     def solr_data
-      { :"#{Spotlight::Engine.config.solr_fields.prefix}spotlight_exhibit_slug_#{slug}#{Spotlight::Engine.config.solr_fields.boolean_suffix}" => true }
+      Spotlight::Engine.config.exhibit_filter.call(self)
     end
 
     def reindex_later

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -83,6 +83,11 @@ module Spotlight
     Spotlight::Engine.config.solr_fields.string_suffix = '_ssim'.freeze
     Spotlight::Engine.config.solr_fields.text_suffix = '_tesim'.freeze
 
+    # A lambda expression that filters the solr index per exhibit
+    config.exhibit_filter = lambda do |exhibit|
+      { :"#{config.solr_fields.prefix}spotlight_exhibit_slug_#{exhibit.slug}#{config.solr_fields.boolean_suffix}" => true }
+    end
+
     Spotlight::Engine.config.resource_global_id_field = :"#{config.solr_fields.prefix}spotlight_resource_id#{config.solr_fields.string_suffix}"
 
     # The solr field that original (largest) images will be stored.


### PR DESCRIPTION
This enables us to use a different field/value to select which documents belong to our exhibit.

This is the alternate PR for #1345 Fixes #1344 