### PR TITLE
Add panel to monitor reindex status.

### DIFF
--- a/app/assets/javascripts/spotlight/reindex_monitor.js
+++ b/app/assets/javascripts/spotlight/reindex_monitor.js
@@ -1,0 +1,109 @@
+Spotlight.onLoad(function() {
+  $('[data-behavior="reindex-monitor"]').reindexMonitor();
+});
+
+(function($) {
+  $.fn.reindexMonitor = function() {
+    var monitorElements = this;
+    var defaultRefreshRate = 3000;
+    var panelContainer;
+
+    $(monitorElements).each(function() {
+      panelContainer = $(this);
+      var monitorUrl = panelContainer.data('monitorUrl');
+      var refreshRate = panelContainer.data('refreshRate') || defaultRefreshRate;
+      setInterval(function() {
+        checkMonitorUrl(monitorUrl);
+      }, refreshRate);
+    });
+
+    function checkMonitorUrl(url) {
+      $.ajax(url).success(success).fail(fail);
+    }
+
+    function success(data) {
+      if (data.in_progress) {
+        monitorPanel().show();
+        updateMonitorPanel(data);
+      } else {
+        monitorPanel().hide();
+      }
+    }
+
+    function fail() { monitorPanel().hide(); }
+
+    function updateMonitorPanel(data) {
+      panelStartDate().text(data.started);
+      panelCurrentDate().text(data.updated_at);
+      panelCompleted().text(data.completed);
+      updatePanelTotals(data);
+      updatePanelErrorMessage(data);
+      updateProgressBar(data);
+    }
+
+    function updateProgressBar(data) {
+      var percentage = calculatePercentage(data);
+      progressBar()
+        .attr('aria-valuemax', data.total)
+        .attr('aria-valuenow', percentage)
+        .css('width', percentage + '%')
+        .text(percentage + '%');
+    }
+
+    function updatePanelErrorMessage(data) {
+      // We currently do not store this state,
+      // but with this code we can in the future.
+      if ( data.errored ) {
+        panelErrorMessage().show();
+      } else {
+        panelErrorMessage().hide();
+      }
+    }
+
+    function updatePanelTotals(data) {
+      panelTotals().each(function() {
+        $(this).text(data.total);
+      });
+    }
+
+    function calculatePercentage(data) {
+      return Math.floor((data.completed / data.total) * 100);
+    }
+
+    function monitorPanel() {
+      return panelContainer.find('.index-status');
+    }
+
+    function panelStartDate() {
+      return monitorPanel()
+               .find('[data-behavior="monitor-start"]')
+               .find('[data-behavior="date"]');
+    }
+
+    function panelCurrentDate() {
+      return monitorPanel()
+               .find('[data-behavior="monitor-current"]')
+               .find('[data-behavior="date"]');
+    }
+
+    function panelTotals() {
+      return monitorPanel().find('[data-behavior="total"]');
+    }
+
+    function panelCompleted() {
+      return monitorPanel()
+               .find('[data-behavior="monitor-current"]')
+               .find('[data-behavior="completed"]');
+    }
+
+    function progressBar() {
+      return monitorPanel().find('.progress-bar');
+    }
+
+    function panelErrorMessage() {
+      return monitorPanel().find('[data-behavior="monitor-error"]');
+    }
+
+    return this;
+  };
+})(jQuery);

--- a/app/controllers/spotlight/resources_controller.rb
+++ b/app/controllers/spotlight/resources_controller.rb
@@ -39,6 +39,10 @@ module Spotlight
     end
     # rubocop:enable Metrics/MethodLength
 
+    def monitor
+      render json: current_exhibit.reindex_progress
+    end
+
     def reindex_all
       @exhibit.reindex_later
 

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -99,6 +99,10 @@ module Spotlight
       roles.first.user if roles.first
     end
 
+    def reindex_progress
+      @reindex_progress ||= ReindexProgress.new(resources.order('updated_at')) if resources
+    end
+
     protected
 
     def add_site_reference

--- a/app/models/spotlight/reindex_progress.rb
+++ b/app/models/spotlight/reindex_progress.rb
@@ -1,0 +1,107 @@
+module Spotlight
+  ##
+  # ReindexProgress is a class that models the progress of reindexing a list of resources
+  class ReindexProgress
+    def initialize(resource_list)
+      @resources = if resource_list.present?
+                     resource_list
+                   else
+                     null_resources
+                   end
+    end
+
+    def in_progress?
+      return unless finished
+      any_waiting? || finished > Spotlight::Engine.config.reindex_progress_window.minutes.ago
+    end
+
+    def started
+      @started ||= resources.first.indexed_at
+    end
+
+    def finished
+      @finished ||= completed_resources.last.updated_at
+    end
+
+    def total
+      @total ||= resources.map(&:last_indexed_estimate).sum
+    end
+
+    def completed
+      @completed ||= completed_resources.map(&:last_indexed_count).sum
+    end
+
+    def errored?
+      resources.any?(&:errored?)
+    end
+
+    def as_json(*)
+      {
+        in_progress: in_progress?,
+        started: localized_start_time,
+        total: total,
+        completed: completed,
+        updated_at: localized_finish_time,
+        errored: errored?
+      }
+    end
+
+    private
+
+    attr_reader :resources
+
+    def any_waiting?
+      resources.any?(&:waiting?)
+    end
+
+    def localized_start_time
+      return unless started
+      I18n.l(started, format: :short)
+    end
+
+    def localized_finish_time
+      return unless finished
+      I18n.l(finished, format: :short)
+    end
+
+    def completed_resources
+      if resources.try(:completed).present?
+        resources.completed
+      else
+        null_resources
+      end
+    end
+
+    def null_resources
+      [NullResource.new]
+    end
+
+    ##
+    # A NullObject for use in the absense of resources
+    class NullResource
+      def updated_at
+        nil
+      end
+
+      def indexed_at
+        nil
+      end
+
+      def last_indexed_estimate
+        0
+      end
+
+      def last_indexed_count
+        0
+      end
+
+      def waiting?
+        false
+      end
+
+      def errored?
+        false
+      end
+    end
+  end
+end

--- a/app/models/spotlight/resource.rb
+++ b/app/models/spotlight/resource.rb
@@ -18,8 +18,11 @@ module Spotlight
       :last_index_elapsed_time,
       :last_indexed_finished], coder: JSON
 
+    enum index_status: [:waiting, :completed, :errored]
+
     around_index :reindex_with_logging
     after_index :commit
+    after_index :completed!
 
     def becomes_provider
       klass = Spotlight::ResourceProvider.for_resource(self)
@@ -46,6 +49,7 @@ module Spotlight
     ##
     # Enqueue an asynchronous reindexing job for this resource
     def reindex_later
+      waiting!
       Spotlight::ReindexJob.perform_later(self)
     end
 

--- a/app/views/spotlight/catalog/_admin_header.html.erb
+++ b/app/views/spotlight/catalog/_admin_header.html.erb
@@ -1,16 +1,19 @@
 <% if can? :manage, Spotlight::Resource.new(exhibit: current_exhibit) %>
-<div class="add-items-nav clearfix">
-  <div class="pull-left">
-    <%= link_to t('.reindex'), reindex_all_exhibit_resources_path(current_exhibit), method: :post, class: 'btn btn-default' %>
+  <div data-behavior='reindex-monitor' data-monitor-url="<%= monitor_exhibit_resources_path(current_exhibit) %>">
+    <%= render 'reindex_progress_panel' %>
   </div>
-  <div class="pull-right">
-    <% if Spotlight::Engine.config.new_resource_partials.any? %>
-      <%= link_to t('.new.repo_item'), new_exhibit_catalog_path(current_exhibit), class: 'btn btn-default' %>
-    <% end %>
-    
-    <% if Spotlight::Engine.config.uploaded_resource_partials.any? %>
-      <%= link_to t('.new.non_repo_item'), new_exhibit_resources_upload_path(current_exhibit), class: 'btn btn-default' %>
-    <% end %>
+  <div class="add-items-nav clearfix">
+    <div class="pull-left">
+      <%= link_to t('.reindex'), reindex_all_exhibit_resources_path(current_exhibit), method: :post, class: 'btn btn-default' %>
+    </div>
+    <div class="pull-right">
+      <% if Spotlight::Engine.config.new_resource_partials.any? %>
+        <%= link_to t('.new.repo_item'), new_exhibit_catalog_path(current_exhibit), class: 'btn btn-default' %>
+      <% end %>
+
+      <% if Spotlight::Engine.config.uploaded_resource_partials.any? %>
+        <%= link_to t('.new.non_repo_item'), new_exhibit_resources_upload_path(current_exhibit), class: 'btn btn-default' %>
+      <% end %>
+    </div>
   </div>
-</div>
 <% end %>

--- a/app/views/spotlight/catalog/_reindex_progress_panel.html.erb
+++ b/app/views/spotlight/catalog/_reindex_progress_panel.html.erb
@@ -1,0 +1,21 @@
+<div class="panel panel-info index-status" style='display:none;'>
+  <div class="panel-heading">
+    <h3 class="panel-title"><%= t('.heading') %></h3>
+  </div>
+  <div class="panel-body">
+    <p data-behavior='monitor-start'>
+      <span class="text-muted" data-behavior='date'></span> <%= t('.begin_html') %>
+    </p>
+    <p data-behavior='monitor-current'>
+      <span class="text-muted" data-behavior='date'></span> <%= t('.completed_html') %>
+    </p>
+
+    <p class="bg-warning" data-behavior='monitor-error' style='display:none;'>
+      <%= t('.error') %>
+    </p>
+
+    <div class="progress">
+      <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="" aria-valuemin="0" aria-valuemax=""></div>
+    </div>
+  </div>
+</div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -264,6 +264,11 @@ en:
           non_repo_item: "Add non-repository item"
       new:
         header: Import items
+      reindex_progress_panel:
+        heading: Reindexing status
+        begin_html: "Began reindexing a total of <span data-behavior='total'></span> items."
+        completed_html: "Reindexed <span data-behavior='completed'></span> of <span data-behavior='total'></span> items."
+        error: 'An error occured while reindexing. Contact your exhibits administrator for more information.'
     invitation_mailer:
       invitation_instructions:
         hello: "Hello %{email}!"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Spotlight::Engine.routes.draw do
 
     resources :resources do
       collection do
+        get :monitor
         post :reindex_all
       end
     end

--- a/db/migrate/20151215192845_add_index_status_to_resources.rb
+++ b/db/migrate/20151215192845_add_index_status_to_resources.rb
@@ -1,0 +1,6 @@
+class AddIndexStatusToResources < ActiveRecord::Migration
+  def change
+    add_column :spotlight_resources, :index_status, :integer
+    add_index :spotlight_resources, :index_status
+  end
+end

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -71,6 +71,8 @@ module Spotlight
     Spotlight::Engine.config.uploaded_resource_partials = ['spotlight/resources/upload/single_item_form', 'spotlight/resources/upload/multi_item_form']
     Spotlight::Engine.config.solr_batch_size = 20
 
+    Spotlight::Engine.config.reindex_progress_window = 10
+
     # Filter resources by exhibit by default
     Spotlight::Engine.config.filter_resources_by_exhibit = true
     # The allowed file extensions for uploading non-repository items.

--- a/spec/controllers/spotlight/resources_controller_spec.rb
+++ b/spec/controllers/spotlight/resources_controller_spec.rb
@@ -12,6 +12,13 @@ describe Spotlight::ResourcesController, type: :controller do
       end
     end
 
+    describe 'GET monitor' do
+      it 'is not allowed' do
+        get :monitor, exhibit_id: exhibit
+        expect(response).to redirect_to main_app.new_user_session_path
+      end
+    end
+
     describe 'POST create' do
       it 'is not allowed' do
         post :create, exhibit_id: exhibit
@@ -47,6 +54,13 @@ describe Spotlight::ResourcesController, type: :controller do
           get :new, exhibit_id: exhibit, popup: true
           expect(response).to render_template 'layouts/spotlight/popup'
         end
+      end
+    end
+
+    describe 'GET monitor' do
+      it 'succesfully renders json' do
+        get :monitor, exhibit_id: exhibit
+        expect(response).to be_success
       end
     end
 

--- a/spec/features/javascript/reindex_monitor_spec.rb
+++ b/spec/features/javascript/reindex_monitor_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+feature 'Reindex Monitor', js: true do
+  let(:resources) do
+    [FactoryGirl.create(:resource, updated_at: Time.zone.now, index_status: 1)]
+  end
+  let(:exhibit) { FactoryGirl.create(:exhibit, resources: resources) }
+  let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
+
+  before do
+    login_as exhibit_curator
+    visit spotlight.admin_exhibit_catalog_index_path(exhibit)
+  end
+
+  it 'is rendered on the item admin page' do
+    expect(page).to have_css('.panel.index-status', visible: true)
+    within('.panel.index-status') do
+      expect(page).to have_css('p', text: /Began reindexing a total of \d items/)
+      expect(page).to have_css('p', text: /Reindexed \d of \d items/)
+    end
+  end
+end

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -233,4 +233,10 @@ describe Spotlight::Exhibit, type: :model do
       end
     end
   end
+
+  describe '#reindex_progress' do
+    it 'returns a Spotlight::ReindexProgress' do
+      expect(subject.reindex_progress).to be_a Spotlight::ReindexProgress
+    end
+  end
 end

--- a/spec/models/spotlight/reindex_progress_spec.rb
+++ b/spec/models/spotlight/reindex_progress_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe Spotlight::ReindexProgress, type: :model do
+  let(:start_time) { 20.minutes.ago }
+  let(:finish_time) { 5.minutes.ago }
+  let(:first_resource) do
+    FactoryGirl.create(
+      :resource,
+      updated_at: 15.minutes.ago,
+      indexed_at: start_time,
+      last_indexed_estimate: 7,
+      last_indexed_count: 5,
+      index_status: 1
+    )
+  end
+  let(:last_resource) do
+    FactoryGirl.create(
+      :resource,
+      updated_at: finish_time,
+      indexed_at: 15.minutes.ago,
+      last_indexed_estimate: 3,
+      last_indexed_count: 2,
+      index_status: 1
+    )
+  end
+  let(:resources) { [first_resource, last_resource] }
+  subject { described_class.new(resources) }
+  let(:json) { JSON.parse(subject.to_json) }
+
+  before do
+    allow(subject).to receive_messages(completed_resources: resources)
+  end
+
+  describe '#in_progress' do
+    context 'when the last resource has been updated within the allotted time' do
+      it 'is true' do
+        expect(subject).to be_in_progress
+      end
+    end
+
+    context 'when any of the resources is makred as waiting' do
+      before do
+        expect(last_resource).to receive_messages(updated_at: 12.minutes.ago)
+        first_resource.waiting!
+      end
+      it 'is true' do
+        expect(subject).to be_in_progress
+      end
+    end
+
+    context 'when the last resources has been updated outside of the allotted time ' do
+      before do
+        expect(last_resource).to receive_messages(updated_at: 12.minutes.ago)
+      end
+      it 'is false' do
+        expect(subject).not_to be_in_progress
+      end
+    end
+
+    it 'is included in the json' do
+      expect(json['in_progress']).to be true
+    end
+  end
+
+  describe '#started' do
+    it 'returns the indexed_at attribute of the first resource' do
+      expect(subject.started).to eq start_time
+    end
+
+    it 'is included in the json as a localized string' do
+      expect(json['started']).to eq I18n.l(start_time, format: :short)
+    end
+  end
+
+  describe '#finished' do
+    it 'returns the updated_at attribute of the last resource' do
+      expect(subject.finished).to eq finish_time
+    end
+
+    it 'is included in the json as a localized string under the updated_at attribute' do
+      expect(json['updated_at']).to eq I18n.l(finish_time, format: :short)
+    end
+  end
+
+  describe '#total' do
+    it 'sums the resources last_indexed_estimate' do
+      expect(subject.total).to eq 10
+    end
+
+    it 'is included in the json' do
+      expect(json['total']).to eq 10
+    end
+  end
+
+  describe '#completed' do
+    it 'sums the resources last_indexed_count' do
+      expect(subject.completed).to eq 7
+    end
+
+    it 'is included in the json' do
+      expect(json['completed']).to eq 7
+    end
+  end
+end

--- a/spec/views/spotlight/catalog/admin.html.erb_spec.rb
+++ b/spec/views/spotlight/catalog/admin.html.erb_spec.rb
@@ -10,6 +10,7 @@ module Spotlight
       allow(view).to receive(:new_exhibit_catalog_path).and_return('')
       allow(view).to receive(:new_exhibit_resources_upload_path).and_return('')
       allow(view).to receive(:reindex_all_exhibit_resources_path).and_return('')
+      allow(view).to receive(:monitor_exhibit_resources_path).and_return('')
       assign(:exhibit, exhibit)
       assign(:response, [])
       stub_template '_search_header.html.erb' => 'header'


### PR DESCRIPTION
Also add an index_status enum column to the Spotlight::Resource to track the index state.
Closes #1220 

![reindex-status-panel](https://cloud.githubusercontent.com/assets/96776/11828128/904feadc-a346-11e5-8afc-d690f6e7bb51.png)
