### PR TITLE
Use naive solr facet query to get facet values and term counts

### DIFF
--- a/app/controllers/spotlight/search_configurations_controller.rb
+++ b/app/controllers/spotlight/search_configurations_controller.rb
@@ -21,7 +21,7 @@ module Spotlight
       add_breadcrumb t(:'spotlight.configuration.sidebar.header'), exhibit_dashboard_path(@exhibit)
       add_breadcrumb t(:'spotlight.configuration.sidebar.search_configuration'), edit_exhibit_search_configuration_path(@exhibit)
 
-      @field_metadata = Spotlight::FieldMetadata.new(repository, @blacklight_configuration.blacklight_config)
+      @field_metadata = Spotlight::FieldMetadata.new(current_exhibit, repository, @blacklight_configuration.blacklight_config)
     end
 
     def update

--- a/app/models/spotlight/field_metadata.rb
+++ b/app/models/spotlight/field_metadata.rb
@@ -2,8 +2,12 @@ module Spotlight
   ##
   # Expose Solr index metadata about fields
   class FieldMetadata
-    attr_reader :repository, :blacklight_config
-    def initialize(repository, blacklight_config)
+    FACET_LIMIT = 20
+
+    attr_reader :exhibit, :repository, :blacklight_config
+
+    def initialize(exhibit, repository, blacklight_config)
+      @exhibit = exhibit
       @repository = repository
       @blacklight_config = blacklight_config
     end
@@ -11,30 +15,44 @@ module Spotlight
     def field(field_name)
       {
         document_count: document_counts.fetch(field_name, 0),
-        value_count: fields.fetch(field_name, {}).fetch('distinct', 0),
-        terms: fields.fetch(field_name, {}).fetch('topTerms', [])
+        value_count: terms.fetch(field_name, []).length,
+        terms: terms.fetch(field_name, [])
       }
+    end
+
+    def search_params
+      search_builder.merge(rows: 0, 'facet.limit' => FACET_LIMIT + 1)
     end
 
     private
 
-    def luke
-      @luke ||= repository.send_and_receive('admin/luke', fl: '*', 'json.nl' => 'map')
+    def search_builder_class
+      blacklight_config.search_builder_class
     end
 
-    def fields
-      luke['fields']
+    def search_builder
+      search_builder_class.new(true, self)
+    end
+
+    def solr_response
+      @solr_response ||= repository.search(search_params.merge('facet.query' => facet_fields.map { |_key, fields| "#{fields.field}:[* TO *]" },
+                                                               'rows' => 0,
+                                                               'facet' => true))
     end
 
     # This gets the number of *documents* with a field
     def document_counts
       @document_count ||= begin
-        solr_resp = repository.search('facet.query' => facet_fields.map { |_key, fields| "#{fields.field}:[* TO *]" },
-                                      'rows' => 0,
-                                      'facet' => true)
-
-        solr_resp['facet_counts']['facet_queries'].each_with_object({}) do |(k, v), h|
+        solr_response.facet_queries.each_with_object({}) do |(k, v), h|
           h[k.split(/:/).first] = v
+        end
+      end
+    end
+
+    def terms
+      @terms ||= begin
+        solr_response.aggregations.each_with_object({}) do |(facet_name, facet), h|
+          h[facet_name] = facet.items.map(&:label)
         end
       end
     end
@@ -42,5 +60,7 @@ module Spotlight
     def facet_fields
       blacklight_config.facet_fields.reject { |_k, v| v.pivot || v.query }
     end
+
+    alias_method :current_exhibit, :exhibit
   end
 end

--- a/app/views/spotlight/search_configurations/_facet_metadata.html.erb
+++ b/app/views/spotlight/search_configurations/_facet_metadata.html.erb
@@ -1,0 +1,12 @@
+<%= content_tag :span, t(:'.document_count', count: metadata[:document_count]) %>
+<% if metadata[:document_count] > 0 %>
+  •
+  <% if metadata[:value_count] > Spotlight::FieldMetadata::FACET_LIMIT %>
+    <%= content_tag :span, t(:'.too_many_values_count', count: Spotlight::FieldMetadata::FACET_LIMIT) %>
+  <% else %>
+    <%= content_tag :span, t(:'.value_count', count: metadata[:value_count]) %>
+  <% end %>
+  <% if metadata[:terms].any? %>
+    <%= tag("span", class: 'btn-with-tooltip glyphicon glyphicon-info-sign', data: {container: 'body', toggle: 'tooltip', placement: 'top', title: metadata[:terms].join(" • ")}) %>
+  <% end %>
+<% end %>

--- a/app/views/spotlight/search_configurations/_facets.html.erb
+++ b/app/views/spotlight/search_configurations/_facets.html.erb
@@ -19,13 +19,7 @@
                     </h3>
                   </div>
                   <div class="facet-metadata col-sm-5">
-                    <%= content_tag :span, t(:'.document_count', count: metadata[:document_count]) %>
-                    <% if metadata[:document_count] > 0 %>
-                      • <%= content_tag :span, t(:'.value_count', count: metadata[:value_count]) %>
-                      <% if metadata[:terms].any? %>
-                        <%= tag("span", class: 'btn-with-tooltip glyphicon glyphicon-info-sign', data: {container: 'body', toggle: 'tooltip', placement: 'top', title: metadata[:terms].keys.map(&:to_s).join(" • ")}) %>
-                      <% end %>
-                    <% end %>
+                    <%= render partial: 'facet_metadata', locals: { metadata: metadata } %>
                   </div>
                   <div class="col-sm-2 pull-right">
                     <a class="btn btn-link collapse-toggle collapsed" role="button" data-toggle="collapse" href="#<%= key.parameterize %>_facet_options" aria-expanded="false" aria-controls="<%= key.parameterize %>_facet_options">

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -183,16 +183,18 @@ en:
           the facets shown in the sidebar to limit a search.  You can select the facets
           that are available for searching below. Click a facet field name to edit its display label.
           Drag and drop facets to specify the order they are displayed in the sidebar.
-        document_count:
-          one: "%{count} item"
-          other:  "%{count} items"
-        value_count:
-          one: "%{count} unique value"
-          other: "%{count} unique values"
         sort_by:
           label: "Sort by:"
           count: Frequency
           index: Value
+      facet_metadata:
+        document_count:
+          one: "%{count} item"
+          other:  "%{count} items"
+        too_many_values_count: "%{count}+ unique values"
+        value_count:
+          one: "%{count} unique value"
+          other: "%{count} unique values"
       sort:
         header: "Sort fields"
         help: >

--- a/spec/views/spotlight/search_configurations/_facet_metadata.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_facet_metadata.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+module Spotlight
+  describe 'spotlight/search_configurations/_facet_metadata', type: :view do
+    before do
+      render partial: 'spotlight/search_configurations/facet_metadata', locals: { metadata: metadata }
+    end
+
+    context 'with a facet without any documents' do
+      let(:metadata) { { document_count: 0 } }
+
+      it 'shows there are no documents' do
+        expect(rendered).to have_content '0 items'
+      end
+    end
+
+    context 'with a facet with a small number of values' do
+      let(:metadata) { { document_count: 1, value_count: 3, terms: %w(a b c) } }
+
+      it 'shows the number of unique values' do
+        expect(rendered).to have_content '1 item'
+        expect(rendered).to have_content '3 unique values'
+        expect(rendered).to have_selector '.btn-with-tooltip'
+      end
+    end
+
+    context 'with a facet with a large number of values' do
+      let(:metadata) { { document_count: 1, value_count: 21, terms: %w() } }
+
+      it 'shows there are many unique values' do
+        expect(rendered).to have_content '20+ unique values'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1333

With a multitenant index, the luke request handler data cannot be scoped to the
current exhibit. Instead, use the search builder and ordinary facet queries to
get the appropriate information (with a slight loss of information -- we can't
get the number of terms in an exhibit, so just give '20+' for large counts)

![screen shot 2015-12-16 at 2 08 45 pm](https://cloud.githubusercontent.com/assets/111218/11855356/8bf4dbec-a3fe-11e5-90f4-df4de3adf971.png)
