### PR TITLE
Responsive grid classes should be defined for both controls and labels

### DIFF
--- a/app/views/spotlight/appearances/edit.html.erb
+++ b/app/views/spotlight/appearances/edit.html.erb
@@ -2,7 +2,7 @@
 <div id="content" class="col-md-9">
   <%= configuration_page_title %>
 
-<%= bootstrap_form_for @exhibit, url: spotlight.exhibit_appearance_path(@exhibit), layout: :horizontal, label_col: 'col-md-3', control_col: 'col-sm-5', html: {data: { autocomplete_exhibit_catalog_index_path: spotlight.autocomplete_exhibit_catalog_index_path(current_exhibit, q: "%QUERY", format: "json") } } do |f| %>
+<%= bootstrap_form_for @exhibit, url: spotlight.exhibit_appearance_path(@exhibit), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-md-5 col-sm-5', html: {data: { autocomplete_exhibit_catalog_index_path: spotlight.autocomplete_exhibit_catalog_index_path(current_exhibit, q: "%QUERY", format: "json") } } do |f| %>
   <% if @exhibit.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@exhibit.errors.count, "error") %> prohibited this page from being saved:</h2>

--- a/app/views/spotlight/contact_forms/new.html.erb
+++ b/app/views/spotlight/contact_forms/new.html.erb
@@ -1,5 +1,5 @@
 <div id="content" class="col-md-9">
-<%= bootstrap_form_for @contact_form, url: spotlight.exhibit_contact_form_path(current_exhibit, @contact_form), layout: :horizontal, label_col: 'col-md-3', control_col: 'col-sm-5' do |f| %>
+<%= bootstrap_form_for @contact_form, url: spotlight.exhibit_contact_form_path(current_exhibit, @contact_form), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-sm-5 col-md-5' do |f| %>
   <h1 class="page-title"><%= t(:'.header') %></h1>
   <div class="row">
     <%= f.text_field :name %>

--- a/app/views/spotlight/metadata_configurations/edit.html.erb
+++ b/app/views/spotlight/metadata_configurations/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spotlight/shared/exhibit_sidebar' %>
 <div id="content" class="col-md-9">
 <%= configuration_page_title %>
-<%= bootstrap_form_for @blacklight_configuration, url: spotlight.exhibit_metadata_configuration_path(@exhibit), layout: :horizontal, label_col: 'col-md-3', control_col: 'col-sm-5' do |f| %>
+<%= bootstrap_form_for @blacklight_configuration, url: spotlight.exhibit_metadata_configuration_path(@exhibit), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-md-5 col-sm-5' do |f| %>
     <h3><%= t(:'.order_header') %></h3>
 
     <p class="instructions"><%= t :'.instructions' %></p>

--- a/app/views/spotlight/search_configurations/edit.html.erb
+++ b/app/views/spotlight/search_configurations/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spotlight/shared/exhibit_sidebar' %>
 <div id="content" class="col-md-9">
   <%= configuration_page_title %>
-  <%= bootstrap_form_for @blacklight_configuration, url: spotlight.exhibit_search_configuration_path(@exhibit), layout: :horizontal, label_col: 'col-md-3', control_col: 'col-sm-5' do |f| %>
+  <%= bootstrap_form_for @blacklight_configuration, url: spotlight.exhibit_search_configuration_path(@exhibit), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-md-5 col-sm-5' do |f| %>
 
     <div role="tabpanel">
       <ul class="nav nav-tabs" role="tablist">

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -1,4 +1,4 @@
-<%= bootstrap_form_for [@search.exhibit, @search], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-7', data: {form_observer: 'true', autocomplete_exhibit_catalog_index_path: spotlight.autocomplete_exhibit_search_path(@search.exhibit, @search, q: "%QUERY", format: "json")}, html: {id: 'edit-search'} do |f| %>
+<%= bootstrap_form_for [@search.exhibit, @search], layout: :horizontal, label_col: 'col-md-2 col-sm-2', control_col: 'col-md-7 col-sm-7', data: {form_observer: 'true', autocomplete_exhibit_catalog_index_path: spotlight.autocomplete_exhibit_search_path(@search.exhibit, @search, q: "%QUERY", format: "json")}, html: {id: 'edit-search'} do |f| %>
   <% if @search.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@search.errors.count, "error") %> prohibited this page from being saved:</h2>


### PR DESCRIPTION
Fixes #1335 

<img width="455" alt="screen shot 2015-12-17 at 10 10 29 am" src="https://cloud.githubusercontent.com/assets/111218/11877811/6b225234-a4a6-11e5-8c9a-744a9176d7a1.png">
