### PR TITLE
avoid error when exhibit is nil

### DIFF
--- a/app/models/spotlight/resource.rb
+++ b/app/models/spotlight/resource.rb
@@ -104,10 +104,9 @@ module Spotlight
       end
 
       def spotlight_resource_metadata_for_solr
-        {
-          Spotlight::Engine.config.resource_global_id_field => (to_global_id.to_s if persisted?),
-          document_model.resource_type_field => self.class.to_s.tableize
-        }
+        hash = { Spotlight::Engine.config.resource_global_id_field => (to_global_id.to_s if persisted?) }
+        hash[document_model.resource_type_field] = self.class.to_s.tableize if document_model
+        hash
       end
 
       def document_model

--- a/spec/models/spotlight/resource_spec.rb
+++ b/spec/models/spotlight/resource_spec.rb
@@ -131,4 +131,10 @@ describe Spotlight::Resource, type: :model do
     expect(subject.data[:a]).to eq 1
     expect(subject.data[:b]).to eq 2
   end
+
+  it "spotlight_resource_metadata_for_solr doesn't error when document_model is nil" do
+    # allows indexing to be trigger outside of the rails app (e.g. at the command line)
+    allow(subject).to receive(:exhibit).and_return(nil)
+    subject.send(:spotlight_resource_metadata_for_solr)
+  end
 end


### PR DESCRIPTION
sul-dlss/spotlight-dor-resources#53 is blocked (see https://travis-ci.org/sul-dlss/spotlight-dor-resources/builds/100713436)

because spotlight-dor-resources/spec/models/spotlight/resources/purl_spec.rb#L129  had this error:

"NoMethodError:
       undefined method `resource_type_field' for nil:NilClass
     # /Users/ndushay/.rvm/gems/ruby-2.2.3/gems/blacklight-spotlight-0.15.0/app/models/spotlight/resource.rb:109:in `spotlight_resource_metadata_for_solr'
..."

I *think* spotlight-dor-resources is trying to allow reindexing to occur outside of the Rails app (i.e. from the command line) and this error stems from that use case.