### PR TITLE
Move Date sort to the bottom of the list in the test-app

### DIFF
--- a/spec/features/edit_search_fields_spec.rb
+++ b/spec/features/edit_search_fields_spec.rb
@@ -54,7 +54,7 @@ describe 'Search Administration', type: :feature do
 
         # #field_labeled doesn't appear to work for disabled inputs
         expect(page).to have_css("input[name='blacklight_configuration[sort_fields][relevance][enable]'][disabled='disabled']")
-        expect(page).to have_css('#nested-sort-fields .dd-item:nth-child(5) h3', text: 'Identifier')
+        expect(page).to have_css('#nested-sort-fields .dd-item:nth-child(5) h3', text: 'Date (new to old)')
 
         uncheck 'blacklight_configuration_sort_fields_title_enabled'
         uncheck 'blacklight_configuration_sort_fields_identifier_enabled'

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -92,8 +92,8 @@ class CatalogController < ApplicationController
     config.add_sort_field 'relevance', sort: 'score desc, sort_title_ssi asc', label: 'Relevance'
     config.add_sort_field 'title', sort: 'sort_title_ssi asc', label: 'Title'
     config.add_sort_field 'type', sort: 'sort_type_ssi asc', label: 'Type'
-    config.add_sort_field 'date', sort: 'sort_date_dtsi asc', label: 'Date (old to new)'
     config.add_sort_field 'source', sort: 'sort_source_ssi asc', label: 'Source'
     config.add_sort_field 'identifier', sort: 'id asc', label: 'Identifier'
+    config.add_sort_field 'date', sort: 'sort_date_dtsi desc', label: 'Date (new to old)'
   end
 end


### PR DESCRIPTION
Closes #1406 

This is purely cosmetic since it is only in the `CatalogController` generated into the internal test app.

### Items Admin Page
<img width="890" alt="admin" src="https://cloud.githubusercontent.com/assets/96776/12312107/6488103c-ba11-11e5-9180-ae55ac4db441.png">

### Search Results Admin Page
<img width="873" alt="search-results" src="https://cloud.githubusercontent.com/assets/96776/12312108/64895abe-ba11-11e5-8211-438d05974ee3.png">
