### PR TITLE
Exhibits admin pages updates

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
@@ -89,3 +89,9 @@ label.radio {
     margin-top: $padding-large-vertical;
   }
 }
+
+@media (max-width: $screen-sm-max) {
+  aside.col-md-3 {
+    padding-left: 0;
+  }
+}

--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -102,6 +102,10 @@
   }
 }
 
+.nav.tags {
+  display: inline-block;
+}
+
 // between the small and medium breakpoints, reduce the size of the image by a little bit
 @media (min-width: $screen-sm-min) and (max-width: $screen-md-max) {
 

--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -130,3 +130,21 @@
     position: relative;
   }
 }
+
+// For the medium breakpoint, reduce the max width of the .exhibit-card to align right-edge of row correctly
+@media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+  .exhibit-card {
+
+    // each card is 3 columns wide
+    max-width: 3 * ($container-md / $grid-columns) - $padding-xs-horizontal;
+  }
+}
+
+// For the small breakpoint, reduce the max width of the .exhibit-card to align right-edge of row correctly
+@media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+  .exhibit-card {
+
+    // each card is 4 columns wide
+    max-width: 4 * ($container-sm / $grid-columns) - $padding-xs-horizontal;
+  }
+}

--- a/app/assets/stylesheets/spotlight/_header.scss
+++ b/app/assets/stylesheets/spotlight/_header.scss
@@ -52,7 +52,6 @@
     @extend .hidden-xs;
 
     display: block;
-    margin-top: $padding-base-vertical;
     padding-bottom: $padding-base-vertical;
     padding-top: $padding-base-vertical;
   }
@@ -90,7 +89,6 @@
 
 .site-title-container {
   max-height: $masthead-height - $navbar-height;
-  
   padding-bottom: $padding-large-vertical;
   padding-top: $padding-large-vertical;
 }

--- a/app/assets/stylesheets/spotlight/_variables.scss
+++ b/app/assets/stylesheets/spotlight/_variables.scss
@@ -11,7 +11,7 @@ $exhibit-card-height: 350px !default;
 $exhibit-card-bg: $well-bg !default;
 $exhibit-card-border: $well-border !default;
 $exhibit-card-gutter: $padding-large-horizontal !default;
-$exhibit-card-image-size: 273px !default;
+$exhibit-card-image-size: 269px !default;
 $exhibit-card-shadow: inset 2px 2px 5px -2px $exhibit-card-border !default;
 
 $navbar-transparent-color: $gray !default;

--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -4,16 +4,16 @@
   <li><%= link_to t('.documentation'), 'https://github.com/sul-dlss/spotlight/wiki/Configuration-settings' %></li>
 
   <% if can? :manage, Spotlight::Site.instance %>
-    <li><%= link_to t(:'spotlight.sites.edit.section'), spotlight.edit_site_path %></li>
+    <li><%= link_to t(:'spotlight.sites.edit.page_title'), spotlight.edit_site_path %></li>
   <% end %>
 
   <% if can? :manange, Spotlight::Exhibit %>
-    <li><%= link_to t(:'spotlight.sites.edit_exhibits.section'), spotlight.edit_site_exhibits_path %></li>
-    <li><%= link_to t(:'spotlight.admin_users.index.section'), spotlight.admin_users_path %></li>
+    <li><%= link_to t(:'spotlight.sites.edit_exhibits.page_title'), spotlight.edit_site_exhibits_path %></li>
+    <li><%= link_to t(:'spotlight.admin_users.index.page_title'), spotlight.admin_users_path %></li>
   <% end %>
 </ul>
 
 <ul class="nav sidenav nav-pills nav-stacked">
-  <li><%= link_to t('.create_exhibit'), new_exhibit_path, class: 'btn btn-default btn-nav', role: 'button' if can? :create, Spotlight::Exhibit %></li>
+  <li><%= link_to t(:'spotlight.sites.new.page_title'), new_exhibit_path, class: 'btn btn-default btn-nav', role: 'button' if can? :create, Spotlight::Exhibit %></li>
 </ul>
 <% end %>

--- a/app/views/spotlight/exhibits/_new_exhibit_form.html.erb
+++ b/app/views/spotlight/exhibits/_new_exhibit_form.html.erb
@@ -1,4 +1,4 @@
-<%= bootstrap_form_for @exhibit, url: ((spotlight.exhibit_path(@exhibit) if @exhibit.persisted?) || spotlight.exhibits_path), layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10', html: {class: "row"} do |f| %>
+<%= bootstrap_form_for @exhibit, url: ((spotlight.exhibit_path(@exhibit) if @exhibit.persisted?) || spotlight.exhibits_path), layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10' do |f| %>
 <div class="row col-md-12">
   <%= f.text_field :title, label: t(:'.fields.title.label'), help: t(:'.fields.title.help_block') %>
   <%= f.text_field :slug, label: t(:'.fields.slug.label'), help: t(:'.fields.slug.help_block') %>

--- a/app/views/spotlight/exhibits/_tags.html.erb
+++ b/app/views/spotlight/exhibits/_tags.html.erb
@@ -1,11 +1,13 @@
 <% if tags.any? %>
 <div class="row">
-  <ul class="nav nav-pills col-md-10 col-md-offset-1 tags">
-    <li class="<%= 'active' if params[:tag].blank? %>"><%= link_to t('.all'), exhibits_path %></li>
+  <div class="col-md-12 text-center">
+    <ul class="nav nav-pills tags">
+      <li class="<%= 'active' if params[:tag].blank? %>"><%= link_to t('.all'), exhibits_path %></li>
 
-    <% tags.sort_by(&:name).each do |tag| %>
-      <li class="<%= 'active' if params[:tag] == tag.name %>"><%= link_to tag.name, exhibits_path(tag: tag.name) %></li>
-    <% end %>
-  </ul>
+      <% tags.sort_by(&:name).each do |tag| %>
+        <li class="<%= 'active' if params[:tag] == tag.name %>"><%= link_to tag.name, exhibits_path(tag: tag.name) %></li>
+      <% end %>
+    </ul>
+  </div>
 </div>
 <% end %>

--- a/app/views/spotlight/exhibits/new.html.erb
+++ b/app/views/spotlight/exhibits/new.html.erb
@@ -1,4 +1,8 @@
 <div id="content" class="col-md-9 exhibit-admin">
-<%= configuration_page_title %>
+<%= page_title t(:'spotlight.sites.new.section') %>
 <%= render 'new_exhibit_form' %>
 </div>
+
+<aside class="col-md-3">
+  <%= render "shared/site_sidebar" %>
+</aside>

--- a/app/views/spotlight/sites/edit.html.erb
+++ b/app/views/spotlight/sites/edit.html.erb
@@ -1,7 +1,7 @@
 <div id="content" class="col-md-9 exhibit-admin">
   <%= page_title(t('.section'), t('.page_title')) %>
   <div role="tabpanel">
-    <%= bootstrap_form_for @site, url: spotlight.site_path, layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10', html: {class: "row"} do |f| %>
+    <%= bootstrap_form_for @site, url: spotlight.site_path, layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10' do |f| %>
       <ul class="nav nav-tabs" role="tablist">
         <li role="presentation" class="active">
           <a href="#basic" aria-controls="basic" role="tab" data-toggle="tab"><%= t(:'.basic_settings.heading') %></a>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -125,15 +125,15 @@ en:
         header: "Settings"
     admin_users:
       create:
-        success: Added user as exhibts adminstrator
+        success: Added user as an exhibits adminstrator
         error: There was a problem adding the user as an exhibits adminstrator
       destroy:
         success: User removed from site adminstrator role
         error: There was a problem removing the user from the site adminstrator role
       index:
-        section: Manage users
-        page_title: Exhibits administrators
-        instructions: Existing exhibit administrators
+        section: Manage exhibits
+        page_title: Manage administrators
+        instructions: Existing exhibits administrators
         add: Add new administrator
         destroy: Remove from role
         save: Add role
@@ -493,7 +493,7 @@ en:
             header: "Cropped image"
             help: >
               Adjust the cropping box to cover the area of the image you want to use
-              as the thumbnail image. Click "Save Changes" to save the cropped area.
+              as the thumbnail image. Click "Save changes" to save the cropped area.
       upload_form: *featured_images_form
 
     resources:
@@ -543,9 +543,12 @@ en:
         role: "Role"
         actions: "Actions"
     sites:
+      new:
+        section: Manage exhibits
+        page_title: Create a new exhibit
       edit:
-        section: Customize appearance
-        page_title: Exhibits landing page
+        section: Manage exhibits
+        page_title: Customize appearance
         basic_settings:
           heading: Title
         site_masthead:
@@ -558,7 +561,7 @@ en:
               You can crop larger images using the cropping tool below.
       edit_exhibits:
         section: Manage exhibits
-        page_title: Existing exhibits
+        page_title: Order exhibits
         instructions: Drag and drop the exhibits below to specify the order in which they are displayed on the exhibits homepage.
     searches: &search
       nav_link: "Browse"

--- a/spec/features/create_exhibit_spec.rb
+++ b/spec/features/create_exhibit_spec.rb
@@ -12,7 +12,7 @@ describe 'Create a new exhibit', type: :feature do
     within '.dropdown-menu' do
       click_link 'Create Exhibit'
     end
-    expect(page).to have_selector 'h1', text: 'Configuration'
+    expect(page).to have_selector 'h1', text: 'Manage exhibits'
     expect(page).to have_selector 'h1 small', text: 'Create a new exhibit'
   end
 

--- a/spec/features/site_admin_management_spec.rb
+++ b/spec/features/site_admin_management_spec.rb
@@ -20,7 +20,7 @@ describe 'Site admin management', js: true do
     fill_in 'user_email', with: existing_user.email
     click_button 'Add role'
 
-    expect(page).to have_content('Added user as exhibts adminstrator')
+    expect(page).to have_content('Added user as an exhibits adminstrator')
     expect(page).to have_css('td', text: existing_user.email)
   end
 


### PR DESCRIPTION
Includes a handful of updates, all related to tidying up the exhibit admin pages:

* Several adjustments for better alignment of page elements
* I updated the page title and subtitles scheme, so that all page titles are "Manage exhibits" and the subtitles are the same as the sidebar links. This is more consistent with how we do things in the exhibit admin pages, and generally feels more logical than the previous scheme.

