### PR TITLE
Remove label that shows tag and browse category counts

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,3 +9,9 @@
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:
   Max: 160
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/NotToNot:
+  Enabled: false

--- a/app/helpers/spotlight/title_helper.rb
+++ b/app/helpers/spotlight/title_helper.rb
@@ -20,15 +20,5 @@ module Spotlight
       @page_title = strip_tags(t(:'spotlight.html_title', title: title || t(:'.title', default: :'.header'), application_name: application_name))
     end
     # rubocop:enable Style/AccessorMethodName
-
-    def header_with_count(*args)
-      title, count = if args.length == 2
-                       args
-                     else
-                       [t(:'.header'), args.first]
-                     end
-
-      safe_join([title, content_tag(:span, count, class: 'label label-default')], ' ')
-    end
   end
 end

--- a/app/views/spotlight/searches/index.html.erb
+++ b/app/views/spotlight/searches/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spotlight/shared/exhibit_sidebar' %>
 <div id="content" class="col-md-9">
   <%= curation_page_title %>
-  <h3><%= header_with_count(t(:'.categories_header'), @searches.count) %></h3>
+  <h3><%= t(:'.categories_header') %></h3>
 
   <% if @searches.empty? %>
     <%= t :'.no_saved_searches' %>

--- a/app/views/spotlight/tags/index.html.erb
+++ b/app/views/spotlight/tags/index.html.erb
@@ -1,6 +1,6 @@
 <%= render 'spotlight/shared/exhibit_sidebar' %>
 <div id="content" class="col-md-9">
-  <%= curation_page_title(header_with_count(@tags.length)) %>
+  <%= curation_page_title t(:".header") %>
 
   <% if @tags.empty? %>
     <p><%= t :'.no_tags' %></p>

--- a/spec/helpers/spotlight/title_helper_spec.rb
+++ b/spec/helpers/spotlight/title_helper_spec.rb
@@ -47,12 +47,4 @@ describe Spotlight::TitleHelper, type: :helper do
       expect(title).to have_selector 'h1 small', text: 'Some title'
     end
   end
-
-  describe '#header_with_count' do
-    it 'merges the title with a count label' do
-      val = helper.header_with_count 'some title', 5
-      expect(val).to include 'some title'
-      expect(val).to have_selector 'span.label', text: 5
-    end
-  end
 end

--- a/spec/views/spotlight/tags/index.html.erb_spec.rb
+++ b/spec/views/spotlight/tags/index.html.erb_spec.rb
@@ -19,10 +19,4 @@ describe 'spotlight/tags/index.html.erb', type: :view do
       end
     end
   end
-  describe 'Total tags' do
-    it 'is displayed' do
-      render
-      expect(rendered).to have_css('span.label.label-default', text: 2)
-    end
-  end
 end


### PR DESCRIPTION
Closes #1440 

Removed label of counts from the Tags and Browse Categories pages. This label wasn't shown on any other pages.

Also removed a helper (and associated test) used to produce the label since it wasn't used anywhere else in the app after I updated the tags and browse categories views.

### Before
![curation_-_tags_3___maps_of_africa__an_online_exhibit_-_online_exhibits](https://cloud.githubusercontent.com/assets/101482/13156457/6236e776-d637-11e5-9c89-3795b1912f22.png)

### After
![curation_-_tags___exhibit_one_-_blacklight](https://cloud.githubusercontent.com/assets/101482/13156469/75f9cf94-d637-11e5-80c9-516f38305423.png)
